### PR TITLE
feat: add possibility to create the configuration

### DIFF
--- a/coffee_github/src/repository.rs
+++ b/coffee_github/src/repository.rs
@@ -131,7 +131,7 @@ impl Repository for Github {
     /// details.
     async fn init(&mut self) -> Result<(), CoffeeError> {
         debug!(
-            "INITIALIZING REPOSITORY: {} {} > {}",
+            "initializing repository: {} {} > {}",
             self.name, &self.url.url_string, &self.url.path_string,
         );
         let res = git2::Repository::clone(&self.url.url_string, &self.url.path_string);

--- a/coffee_lib/src/cln_conf.rs
+++ b/coffee_lib/src/cln_conf.rs
@@ -1,16 +1,34 @@
 //! Manage core lightning configuration
+use std::fmt::Display;
+
+use log::debug;
+
 use crate::plugin::Plugin;
 
 pub struct CLNConf {
+    pub path: String,
     pub network: String,
     pub plugins: Vec<Plugin>,
 }
 
 impl CLNConf {
-    pub fn new(network: &str) -> Self {
+    pub fn new(network: &str, path: &str) -> Self {
         CLNConf {
+            path: path.to_owned(),
             network: network.to_string(),
             plugins: vec![],
         }
+    }
+}
+
+impl Display for CLNConf {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut conf_str = "# reckless configuration\n".to_owned();
+        for plugin in &self.plugins {
+            conf_str += format!("plugin={}\n", plugin.path).as_str();
+        }
+        debug!("store the following cln conf");
+        debug!("{conf_str}");
+        write!(f, "{conf_str}")
     }
 }

--- a/coffee_lib/src/utils.rs
+++ b/coffee_lib/src/utils.rs
@@ -1,7 +1,4 @@
 use crate::errors::CoffeeError;
-use crate::url::URL;
-use git2;
-use log::debug;
 use std::path::Path;
 
 pub fn get_plugin_info_from_path(path: &Path) -> Result<(String, String), CoffeeError> {

--- a/coffee_storage/src/file.rs
+++ b/coffee_storage/src/file.rs
@@ -7,7 +7,7 @@
 //! a more smart version of storage manager
 use crate::storage::StorageManager;
 use async_trait::async_trait;
-use coffee_lib::{errors::CoffeeError, plugin_manager::PluginManager};
+use coffee_lib::errors::CoffeeError;
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::{
     fs::File,


### PR DESCRIPTION
This fixes a couple of bugs and adds the support to create the core lightning configuration, now the step missed is loading the configuration and link it to core lightning

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>