### PR TITLE
Refactor CoffeeCommand::Remove to use plugin parameter

### DIFF
--- a/coffee_cmd/src/main.rs
+++ b/coffee_cmd/src/main.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), CoffeeError> {
     let mut coffee = CoffeeManager::new(&args).await?;
     let result = match args.command {
         CoffeeCommand::Install { plugin } => coffee.install(&plugin).await,
-        CoffeeCommand::Remove => todo!(),
+        CoffeeCommand::Remove { plugin } => coffee.remove(&plugin).await,
         CoffeeCommand::List => coffee.list().await,
         CoffeeCommand::Upgrade => coffee.upgrade(&[""]).await,
         CoffeeCommand::Remote { action } => {


### PR DESCRIPTION
This commit refactors the CoffeeCommand::Remove method to accept a plugin parameter instead of using a placeholder todo!() statement. The plugin parameter is then used to call the remove method on the coffee instance, using the await keyword to ensure the operation completes before continuing.