### PR TITLE
fix: Support the verbose output while running the install and upgrade command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "albert_stream"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0eb452e0d760aaeb2339812aef595b287a782b10ccb9a09ec9fefddf809f1ca"
+
+[[package]]
 name = "async-trait"
 version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,11 +110,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "clightningrpc-conf"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ae2939b521bad1373cab778c552deac98872ca59895104767cea1005cdbd5d"
+dependencies = [
+ "albert_stream",
+ "indexmap",
+]
+
+[[package]]
 name = "coffee_cmd"
 version = "0.0.1-alpha.1"
 dependencies = [
  "async-trait",
  "clap",
+ "clightningrpc-conf",
  "coffee_github",
  "coffee_lib",
  "coffee_storage",

--- a/coffee_cmd/Cargo.toml
+++ b/coffee_cmd/Cargo.toml
@@ -14,3 +14,4 @@ log = "0.4.17"
 env_logger = "0.9.3"
 coffee_storage = { path = "../coffee_storage"  }
 serde = { version = "1.0", features = ["derive"] }
+clightningrpc-conf = "0.0.1"

--- a/coffee_cmd/src/coffee/cmd.rs
+++ b/coffee_cmd/src/coffee/cmd.rs
@@ -17,9 +17,14 @@ pub struct CoffeeArgs {
 /// Coffee subcommand of the command line daemon.
 #[derive(Debug, Subcommand)]
 pub enum CoffeeCommand {
-    /// Install a single or a list of plugins.
+    /// Install a single by name.
     #[clap(arg_required_else_help = true)]
-    Install { plugin: String },
+    Install {
+        plugin: String,
+
+        #[arg(short, long ,action = clap::ArgAction::SetTrue)]
+        verbose: bool,
+    },
     /// upgrade a single or a list of plugins.
     #[clap(arg_required_else_help = true)]
     Upgrade,
@@ -35,6 +40,10 @@ pub enum CoffeeCommand {
         #[clap(subcommand)]
         action: RemoteAction,
     },
+    /// Configur coffe with the core lightning
+    /// configuration
+    #[clap(arg_required_else_help = true)]
+    Setup { cln_conf: String },
 }
 
 #[derive(Debug, Subcommand)]

--- a/coffee_cmd/src/coffee/config.rs
+++ b/coffee_cmd/src/coffee/config.rs
@@ -1,9 +1,8 @@
 //! Coffee configuration utils.
 
-use std::{env, path::Path};
-
 use coffee_lib::errors::CoffeeError;
 use serde::{Deserialize, Serialize};
+use std::{env, path::Path};
 use tokio::fs::create_dir;
 
 use super::cmd::CoffeeArgs;
@@ -15,8 +14,13 @@ pub struct CoffeeConf {
     /// Network configuration related
     /// to core lightning network
     pub network: String,
-    /// core lightning configuration file path
-    pub cln_config: String,
+    /// path of core lightning configuration file
+    /// managed by coffe
+    pub config_path: String,
+    /// path of the core lightnign configuration file
+    /// not managed by core lightning
+    /// (this file included the file managed by coffe)
+    pub cln_config_path: Option<String>,
     /// root path plugin manager
     pub root_path: String,
     /// path of all plugin that are installed
@@ -44,8 +48,9 @@ impl CoffeeConf {
         let mut coffee = CoffeeConf {
             network: "bitcoin".to_owned(),
             root_path: format!("{def_path}"),
-            cln_config: format!("{def_path}/bitcoin/coffee.conf"),
+            config_path: format!("{def_path}/bitcoin/coffee.conf"),
             plugins_path: vec![],
+            cln_config_path: None,
         };
 
         // check the command line arguments and bind them
@@ -66,11 +71,11 @@ impl CoffeeConf {
     fn bind_cmd_line_params(&mut self, conf: &CoffeeArgs) -> Result<(), CoffeeError> {
         if let Some(network) = &conf.network {
             self.network = network.to_owned();
-            self.cln_config = format!("{}/{}/coffee.conf", self.root_path, self.network);
+            self.config_path = format!("{}/{}/coffee.conf", self.root_path, self.network);
         }
 
         if let Some(config) = &conf.conf {
-            self.cln_config = config.to_owned();
+            self.config_path = config.to_owned();
         }
 
         // FIXME: be able to put the directory also in another place!

--- a/coffee_cmd/src/main.rs
+++ b/coffee_cmd/src/main.rs
@@ -1,5 +1,7 @@
 mod coffee;
 
+// use std::ptr::null;
+
 use crate::coffee::cmd::CoffeeArgs;
 use clap::Parser;
 use coffee::cmd::CoffeeCommand;
@@ -15,7 +17,7 @@ async fn main() -> Result<(), CoffeeError> {
     let args = CoffeeArgs::parse();
     let mut coffee = CoffeeManager::new(&args).await?;
     let result = match args.command {
-        CoffeeCommand::Install { plugin } => coffee.install(&plugin).await,
+        CoffeeCommand::Install { plugin, verbose } => coffee.install(&plugin, verbose).await,
         CoffeeCommand::Remove => todo!(),
         CoffeeCommand::List => coffee.list().await,
         CoffeeCommand::Upgrade => coffee.upgrade(&[""]).await,
@@ -25,6 +27,11 @@ async fn main() -> Result<(), CoffeeError> {
             } else {
                 Err(CoffeeError::new(1, "unsupported command"))
             }
+        }
+        CoffeeCommand::Setup { cln_conf } => {
+            // FIXME: read the core lightning confi and
+            // and the coffe script
+            coffee.setup(&cln_conf).await
         }
     };
 

--- a/coffee_lib/src/errors.rs
+++ b/coffee_lib/src/errors.rs
@@ -34,3 +34,12 @@ impl From<std::io::Error> for CoffeeError {
         }
     }
 }
+
+impl From<String> for CoffeeError {
+    fn from(value: String) -> Self {
+        CoffeeError {
+            code: 1,
+            msg: value,
+        }
+    }
+}

--- a/coffee_lib/src/plugin_manager.rs
+++ b/coffee_lib/src/plugin_manager.rs
@@ -11,7 +11,7 @@ pub trait PluginManager {
     async fn configure(&mut self) -> Result<(), CoffeeError>;
 
     /// install a plugin by name, return an error if some error happens.
-    async fn install(&mut self, plugins: &str) -> Result<(), CoffeeError>;
+    async fn install(&mut self, plugins: &str, verbose: bool) -> Result<(), CoffeeError>;
 
     /// return the list of plugin manager by the plugin manager.
     async fn list(&mut self) -> Result<(), CoffeeError>;
@@ -21,4 +21,8 @@ pub trait PluginManager {
 
     /// add the remote repository to the plugin manager.
     async fn add_remote(&mut self, name: &str, url: &str) -> Result<(), CoffeeError>;
+
+    /// set up the core lightning configuration target for the
+    /// plugin manager.
+    async fn setup(&mut self, cln_conf_path: &str) -> Result<(), CoffeeError>;
 }


### PR DESCRIPTION
In the main.rs file, 

Running the install command without the --verbose flag, produces this ouput:
{Note: the file is already present on my local system that's why it is showing the error}

```
$ cargo run -- install rebalance 
 Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/coffee_cmd install rebalance`
[2023-02-28T08:05:21Z ERROR coffee_lib::errors] ERROR #1: field plugin with value /home/harshit/.coffee/repositories/lightningd/rebalance/rebalance.py already present
thread 'main' panicked at 'code: 1, msg: field plugin with value /home/harshit/.coffee/repositories/lightningd/rebalance/rebalance.py already present', coffee_cmd/src/main.rs:42:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```


Running the install command with the --verbose flag, produces this ouput:

```
cargo run -- install rebalance --verbose
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running target/debug/coffee_cmd install rebalance --verbose
Defaulting to user installation because normal site-packages is not writeable
Requirement already satisfied: pyln-client>=0.12 in /home/harshit/.local/lib/python3.10/site-packages (from -r /home/harshit/.coffee/repositories/lightningd/rebalance/requirements.txt (line 1)) (0.12.1)
Requirement already satisfied: pyln-bolt7>=1.0 in /home/harshit/.local/lib/python3.10/site-packages (from pyln-client>=0.12->-r /home/harshit/.coffee/repositories/lightningd/rebalance/requirements.txt (line 1)) (1.0.246)
Requirement already satisfied: pyln-proto>=0.12 in /home/harshit/.local/lib/python3.10/site-packages (from pyln-client>=0.12->-r /home/harshit/.coffee/repositories/lightningd/rebalance/requirements.txt (line 1)) (0.12.0)
Requirement already satisfied: PySocks<2.0.0,>=1.7.1 in /home/harshit/.local/lib/python3.10/site-packages (from pyln-proto>=0.12->pyln-client>=0.12->-r /home/harshit/.coffee/repositories/lightningd/rebalance/requirements.txt (line 1)) (1.7.1)
Requirement already satisfied: cryptography<37.0.0,>=36.0.1 in /home/harshit/.local/lib/python3.10/site-packages (from pyln-proto>=0.12->pyln-client>=0.12->-r /home/harshit/.coffee/repositories/lightningd/rebalance/requirements.txt (line 1)) (36.0.2)
Requirement already satisfied: base58<3.0.0,>=2.1.1 in /home/harshit/.local/lib/python3.10/site-packages (from pyln-proto>=0.12->pyln-client>=0.12->-r /home/harshit/.coffee/repositories/lightningd/rebalance/requirements.txt (line 1)) (2.1.1)
Requirement already satisfied: coincurve<18.0.0,>=17.0.0 in /home/harshit/.local/lib/python3.10/site-packages (from pyln-...
```

shows all the tasks running behind the process.

In the `coffee_lib/src/plugins.rs` file I've just checked whether the --verbose flag is present or not.

fixes #44 