### PR TITLE
feat: Support the verbose output while running the install and upgrade command

### DIFF
--- a/coffee_cmd/src/coffee/cmd.rs
+++ b/coffee_cmd/src/coffee/cmd.rs
@@ -19,7 +19,12 @@ pub struct CoffeeArgs {
 pub enum CoffeeCommand {
     /// Install a single by name.
     #[clap(arg_required_else_help = true)]
-    Install { plugin: String },
+    Install {
+        plugin: String,
+
+        #[arg(short, long, action = clap::ArgAction::SetTrue)]
+        verbose: bool,
+    },
     /// upgrade a single or a list of plugins.
     #[clap(arg_required_else_help = true)]
     Upgrade,

--- a/coffee_cmd/src/coffee/mod.rs
+++ b/coffee_cmd/src/coffee/mod.rs
@@ -146,12 +146,12 @@ impl PluginManager for CoffeeManager {
         Ok(())
     }
 
-    async fn install(&mut self, plugin: &str) -> Result<(), CoffeeError> {
+    async fn install(&mut self, plugin: &str, verbose: bool) -> Result<(), CoffeeError> {
         debug!("installing plugin: {plugin}");
         // keep track if the plugin that are installed with success
         for repo in &self.repos {
             if let Some(mut plugin) = repo.get_plugin_by_name(plugin) {
-                let result = plugin.configure().await;
+                let result = plugin.configure(verbose).await;
                 match result {
                     Ok(path) => {
                         debug!("runnable plugin path {path}");

--- a/coffee_cmd/src/main.rs
+++ b/coffee_cmd/src/main.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), CoffeeError> {
     let args = CoffeeArgs::parse();
     let mut coffee = CoffeeManager::new(&args).await?;
     let result = match args.command {
-        CoffeeCommand::Install { plugin } => coffee.install(&plugin).await,
+        CoffeeCommand::Install { plugin, verbose } => coffee.install(&plugin, verbose).await,
         CoffeeCommand::Remove => todo!(),
         CoffeeCommand::List => coffee.list().await,
         CoffeeCommand::Upgrade => coffee.upgrade(&[""]).await,

--- a/coffee_lib/src/plugin.rs
+++ b/coffee_lib/src/plugin.rs
@@ -30,14 +30,17 @@ impl PluginLang {
                  * 2. return the path of the main file */
                 let req_file = format!("{path}/requirements.txt");
                 let main_file = format!("{path}/{name}.py");
-                // FIXME: enable the verbose command
-                let mut child = Command::new("pip")
-                    .arg("install")
-                    .arg("-r")
-                    .arg(req_file.as_str())
-                    .spawn()
-                    .expect("not possible run the command");
-                let _ = child.wait().await?;
+                let mut cmd = Command::new("pip");
+                cmd.arg("install").arg("-r").arg(&req_file.clone());
+                if verbose {
+                    let _ = cmd
+                        .spawn()
+                        .expect("Unable to run the command")
+                        .wait()
+                        .await?;
+                } else {
+                    let _ = cmd.output().await?;
+                }
                 Ok(main_file)
             }
             PluginLang::Go => {

--- a/coffee_lib/src/plugin.rs
+++ b/coffee_lib/src/plugin.rs
@@ -18,7 +18,12 @@ pub enum PluginLang {
 }
 
 impl PluginLang {
-    pub async fn default_install(&self, path: &str, name: &str) -> Result<String, CoffeeError> {
+    pub async fn default_install(
+        &self,
+        path: &str,
+        name: &str,
+        verbose: bool,
+    ) -> Result<String, CoffeeError> {
         match self {
             PluginLang::Python => {
                 /* 1. RUN PIP install or poetry install
@@ -94,7 +99,7 @@ impl Plugin {
     /// configure the plugin in order to work with cln.
     ///
     /// In case of success return the path of the executable.
-    pub async fn configure(&mut self) -> Result<String, CoffeeError> {
+    pub async fn configure(&mut self, verbose: bool) -> Result<String, CoffeeError> {
         let exec_path = if let Some(conf) = &self.conf {
             if let Some(script) = &conf.plugin.install {
                 let cmds = script.split("\n"); // Check if the script contains `\`
@@ -107,10 +112,14 @@ impl Plugin {
                 }
                 format!("{}/{}", self.path, conf.plugin.main)
             } else {
-                self.lang.default_install(&self.path, &self.name).await?
+                self.lang
+                    .default_install(&self.path, &self.name, verbose)
+                    .await?
             }
         } else {
-            self.lang.default_install(&self.path, &self.name).await?
+            self.lang
+                .default_install(&self.path, &self.name, verbose)
+                .await?
         };
         Ok(exec_path)
     }

--- a/coffee_lib/src/plugin_manager.rs
+++ b/coffee_lib/src/plugin_manager.rs
@@ -11,7 +11,7 @@ pub trait PluginManager {
     async fn configure(&mut self) -> Result<(), CoffeeError>;
 
     /// install a plugin by name, return an error if some error happens.
-    async fn install(&mut self, plugins: &str) -> Result<(), CoffeeError>;
+    async fn install(&mut self, plugins: &str, verbose: bool) -> Result<(), CoffeeError>;
 
     /// return the list of plugin manager by the plugin manager.
     async fn list(&mut self) -> Result<(), CoffeeError>;


### PR DESCRIPTION
In the main.rs file, 

Running the install command without the --verbose flag, produces this ouput:
{Note: the file is already present on my local system that's why it is showing the error}

```
$ cargo run -- install rebalance 
 Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/coffee_cmd install rebalance`
[2023-02-28T08:05:21Z ERROR coffee_lib::errors] ERROR #1: field plugin with value /home/harshit/.coffee/repositories/lightningd/rebalance/rebalance.py already present
thread 'main' panicked at 'code: 1, msg: field plugin with value /home/harshit/.coffee/repositories/lightningd/rebalance/rebalance.py already present', coffee_cmd/src/main.rs:42:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```


Running the install command with the --verbose flag, produces this ouput:

```
cargo run -- install rebalance --verbose
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running target/debug/coffee_cmd install rebalance --verbose
Defaulting to user installation because normal site-packages is not writeable
Requirement already satisfied: pyln-client>=0.12 in /home/harshit/.local/lib/python3.10/site-packages (from -r /home/harshit/.coffee/repositories/lightningd/rebalance/requirements.txt (line 1)) (0.12.1)
Requirement already satisfied: pyln-bolt7>=1.0 in /home/harshit/.local/lib/python3.10/site-packages (from pyln-client>=0.12->-r /home/harshit/.coffee/repositories/lightningd/rebalance/requirements.txt (line 1)) (1.0.246)
Requirement already satisfied: pyln-proto>=0.12 in /home/harshit/.local/lib/python3.10/site-packages (from pyln-client>=0.12->-r /home/harshit/.coffee/repositories/lightningd/rebalance/requirements.txt (line 1)) (0.12.0)
Requirement already satisfied: PySocks<2.0.0,>=1.7.1 in /home/harshit/.local/lib/python3.10/site-packages (from pyln-proto>=0.12->pyln-client>=0.12->-r /home/harshit/.coffee/repositories/lightningd/rebalance/requirements.txt (line 1)) (1.7.1)
Requirement already satisfied: cryptography<37.0.0,>=36.0.1 in /home/harshit/.local/lib/python3.10/site-packages (from pyln-proto>=0.12->pyln-client>=0.12->-r /home/harshit/.coffee/repositories/lightningd/rebalance/requirements.txt (line 1)) (36.0.2)
Requirement already satisfied: base58<3.0.0,>=2.1.1 in /home/harshit/.local/lib/python3.10/site-packages (from pyln-proto>=0.12->pyln-client>=0.12->-r /home/harshit/.coffee/repositories/lightningd/rebalance/requirements.txt (line 1)) (2.1.1)
Requirement already satisfied: coincurve<18.0.0,>=17.0.0 in /home/harshit/.local/lib/python3.10/site-packages (from pyln-...
```

shows all the tasks running behind the process.

In the `coffee_lib/src/plugins.rs` file I've just checked whether the --verbose flag is present or not.

fixes #44 