### PR TITLE
Store installed plugins as a vector of plugin struct

### DIFF
--- a/coffee_cmd/src/coffee/config.rs
+++ b/coffee_cmd/src/coffee/config.rs
@@ -1,6 +1,6 @@
 //! Coffee configuration utils.
 
-use coffee_lib::errors::CoffeeError;
+use coffee_lib::{errors::CoffeeError, plugin::Plugin};
 use serde::{Deserialize, Serialize};
 use std::{env, path::Path};
 use tokio::fs::create_dir;
@@ -23,9 +23,9 @@ pub struct CoffeeConf {
     pub cln_config_path: Option<String>,
     /// root path plugin manager
     pub root_path: String,
-    /// path of all plugin that are installed
+    /// all plugins that are installed
     /// with the plugin manager.
-    pub plugins_path: Vec<String>,
+    pub plugins: Vec<Plugin>,
 }
 
 async fn check_dir_or_make_if_missing(path: String) -> Result<(), CoffeeError> {
@@ -49,7 +49,7 @@ impl CoffeeConf {
             network: "bitcoin".to_owned(),
             root_path: format!("{def_path}"),
             config_path: format!("{def_path}/bitcoin/coffee.conf"),
-            plugins_path: vec![],
+            plugins: vec![],
             cln_config_path: None,
         };
 

--- a/coffee_cmd/src/coffee/mod.rs
+++ b/coffee_cmd/src/coffee/mod.rs
@@ -156,7 +156,7 @@ impl PluginManager for CoffeeManager {
                 match result {
                     Ok(path) => {
                         debug!("runnable plugin path {path}");
-                        self.config.plugins_path.push(path.to_string());
+                        self.config.plugins.push(plugin);
                         self.coffe_cln_config
                             .add_conf("plugin", &path.to_owned())
                             .map_err(|err| CoffeeError::new(1, &err.cause))?;


### PR DESCRIPTION
# Description

Instead of just storing the plugin path as a string in a vector, we store the plugin information as a vector of Plugins.
The struct Plugin contains:
- `name` The name of the plugin
- `path` The path of the plugin
- `lang` The language of the plugin
- `conf` The configuration of the plugin

This paves the way for implementing the `list` function. We can then simply iterate over `plugins` vector and get the information we want and format the output as needed.

Fixes #53 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- This builds normally on my machine 
- I ran `make` locally before pushing this code 

**Test Configuration**:
- Firmware version: Ubuntu 20.04.5 LTS
- Running Bitcoin Core Signet
- Running Core Lightning using btcli4j plugin


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings