### PR TITLE
fix: avoid to override the language when found

### DIFF
--- a/coffee_cmd/src/coffee/config.rs
+++ b/coffee_cmd/src/coffee/config.rs
@@ -9,7 +9,7 @@ use super::cmd::CoffeeArgs;
 
 /// Custom coffee configuration, given by a command line list of arguments
 /// or a coffee configuration file.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CoffeeConf {
     /// Network configuration related
     /// to core lightning network

--- a/coffee_cmd/src/coffee/mod.rs
+++ b/coffee_cmd/src/coffee/mod.rs
@@ -151,6 +151,7 @@ impl PluginManager for CoffeeManager {
         // keep track if the plugin that are installed with success
         for repo in &self.repos {
             if let Some(mut plugin) = repo.get_plugin_by_name(plugin) {
+                debug!("{:#?}", plugin);
                 let result = plugin.configure(verbose).await;
                 match result {
                     Ok(path) => {

--- a/coffee_github/src/repository.rs
+++ b/coffee_github/src/repository.rs
@@ -92,19 +92,21 @@ impl Github {
                                     ))
                                 }
                             };
-                            conf = Some(conf_file)
+                            conf = Some(conf_file);
+                            break;
                         }
                     }
 
                     // check if there was a coffee configuration file
                     if conf == None {
+                        debug!("conf file not found, so we try to guess the language");
                         // try to understand the language from the file
                         let files = WalkDir::new(plugin_path.path()).max_depth(1);
                         for file in files {
                             let file_dir = file.unwrap().clone();
                             (path_to_plugin, plugin_name) =
                                 get_plugin_info_from_path(file_dir.path()).unwrap();
-
+                            debug!("looking for {plugin_name} in {path_to_plugin}");
                             let file_name = file_dir.file_name().to_str().unwrap();
                             plugin_lang = match file_name {
                                 "requirements.txt" => PluginLang::Python,
@@ -115,6 +117,9 @@ impl Github {
                                 "tsconfig.json" => PluginLang::TypeScript,
                                 _ => PluginLang::Unknown,
                             };
+                            if plugin_lang != PluginLang::Unknown {
+                                break;
+                            }
                         }
                         debug!("possible plugin language: {:?}", plugin_lang);
                     }

--- a/coffee_lib/src/plugin.rs
+++ b/coffee_lib/src/plugin.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use tokio::process::Command;
 
 /// Plugin language definition
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum PluginLang {
     Python,
     Go,


### PR DESCRIPTION
Fix to avoid overriding the language when it is found.

When we found what we are looking for we return and stop to search.

Fixes 4016ce84

Introduced in https://github.com/coffee-tools/coffee/pull/50

cc @tareknaser360 