### PR TITLE
Create core lightning config file if missing

### DIFF
--- a/coffee_cmd/src/coffee/mod.rs
+++ b/coffee_cmd/src/coffee/mod.rs
@@ -117,7 +117,7 @@ impl CoffeeManager {
             return Ok(());
         }
         let path = self.config.cln_config_path.clone().unwrap();
-        let mut file = CLNConf::new(path, false);
+        let mut file = CLNConf::new(path, true);
         file.parse()
             .map_err(|err| CoffeeError::new(err.core, &err.cause))?;
         debug!("{:#?}", file.fields);


### PR DESCRIPTION
# Description
This option is already implemented in CLNConf Parser.
`pub(crate) fn new(file_path: &str, create_if_missing: bool)`


I just set `create_if_missing` to be true.

Fixes #57 