### PR TITLE
Adding support for `list` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "git2",
  "log",
  "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/coffee_cmd/src/coffee/cmd.rs
+++ b/coffee_cmd/src/coffee/cmd.rs
@@ -31,9 +31,12 @@ pub enum CoffeeCommand {
     /// upgrade a single or a list of plugins.
     #[clap(arg_required_else_help = true)]
     Upgrade,
-    /// Print the list of plugin installed in cln.
-    #[clap(arg_required_else_help = true)]
-    List,
+    /// Print the list of plugins installed in cln.
+    #[clap(arg_required_else_help = false)]
+    List {
+        #[arg(short, long, action = clap::ArgAction::SetTrue)]
+        remotes: bool,
+    },
     /// Remove a plugin installed in cln.
     #[clap(arg_required_else_help = true)]
     Remove,

--- a/coffee_cmd/src/main.rs
+++ b/coffee_cmd/src/main.rs
@@ -21,7 +21,13 @@ async fn main() -> Result<(), CoffeeError> {
             dynamic,
         } => coffee.install(&plugin, verbose, dynamic).await,
         CoffeeCommand::Remove => todo!(),
-        CoffeeCommand::List => coffee.list().await,
+        CoffeeCommand::List { remotes } => match coffee.list(remotes).await {
+            Ok(val) => {
+                println!("{}", serde_json::to_string_pretty(&val).unwrap());
+                Ok(())
+            }
+            Err(err) => Err(err),
+        },
         CoffeeCommand::Upgrade => coffee.upgrade(&[""]).await,
         CoffeeCommand::Remote { action } => {
             if let RemoteAction::Add { name, url } = action {

--- a/coffee_github/src/repository.rs
+++ b/coffee_github/src/repository.rs
@@ -182,11 +182,18 @@ impl Repository for Github {
     }
 
     /// list of the plugin installed inside the repository.
-    ///
-    /// M.B: in the future we want also list all the plugin installed
-    /// inside the repository.
     async fn list(&self) -> Result<Vec<Plugin>, CoffeeError> {
         Ok(self.plugins.clone())
+    }
+
+    /// name of the repository.
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    /// url of the repository.
+    fn url(&self) -> URL {
+        self.url.clone()
     }
 
     /// search inside the repository a plugin by name.

--- a/coffee_lib/Cargo.toml
+++ b/coffee_lib/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 async-trait = "^0.1.57"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 git2 = "0.16.1"
 log = "0.4.17"
 env_logger = "0.9.3"

--- a/coffee_lib/src/plugin_manager.rs
+++ b/coffee_lib/src/plugin_manager.rs
@@ -1,5 +1,6 @@
 //! Plugin manager module definition.
 use async_trait::async_trait;
+use serde_json::Value;
 
 use crate::errors::CoffeeError;
 
@@ -18,8 +19,8 @@ pub trait PluginManager {
         try_dynamic: bool,
     ) -> Result<(), CoffeeError>;
 
-    /// return the list of plugin manager by the plugin manager.
-    async fn list(&mut self) -> Result<(), CoffeeError>;
+    /// return the list of plugins installed by the plugin manager.
+    async fn list(&mut self, remotes: bool) -> Result<Value, CoffeeError>;
 
     /// upgrade a sequence of plugin managed by the plugin manager.
     async fn upgrade(&mut self, plugins: &[&str]) -> Result<(), CoffeeError>;

--- a/coffee_lib/src/repository.rs
+++ b/coffee_lib/src/repository.rs
@@ -4,6 +4,7 @@ use std::any::Any;
 
 use crate::errors::CoffeeError;
 use crate::plugin::Plugin;
+use crate::url::URL;
 
 use async_trait::async_trait;
 
@@ -20,6 +21,12 @@ pub trait Repository: Any {
 
     /// return the list of plugin that are register contained inside the repository.
     async fn list(&self) -> Result<Vec<Plugin>, CoffeeError>;
+
+    /// return the name of the repository.
+    fn name(&self) -> String;
+
+    /// return the url of the repository.
+    fn url(&self) -> URL;
 
     fn as_any(&self) -> &dyn Any;
 }


### PR DESCRIPTION
# Description

- Running `cargo run -- list` shows all the plugin that is installed by coffee in JSON format
- Running `cargo run -- list --remotes` shows all the plugin that available to install from the added remote repositories 

Fixes #42  