### PR TITLE
allow to run the plugin in a dynamic way 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clightningrpc-common"
+version = "0.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d9821ddb8b5eee8f922fea6871f8684cf3eb74a1cb54f6a6782df70fe28b37"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "clightningrpc-conf"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +135,7 @@ version = "0.0.1-alpha.1"
 dependencies = [
  "async-trait",
  "clap",
+ "clightningrpc-common",
  "clightningrpc-conf",
  "coffee_github",
  "coffee_lib",

--- a/coffee_cmd/Cargo.toml
+++ b/coffee_cmd/Cargo.toml
@@ -15,3 +15,4 @@ env_logger = "0.9.3"
 coffee_storage = { path = "../coffee_storage"  }
 serde = { version = "1.0", features = ["derive"] }
 clightningrpc-conf = "0.0.1"
+clightningrpc-common = "0.3.0-beta.3"

--- a/coffee_cmd/src/coffee/cmd.rs
+++ b/coffee_cmd/src/coffee/cmd.rs
@@ -21,9 +21,10 @@ pub enum CoffeeCommand {
     #[clap(arg_required_else_help = true)]
     Install {
         plugin: String,
-
         #[arg(short, long, action = clap::ArgAction::SetTrue)]
         verbose: bool,
+        #[arg(short, long, action = clap::ArgAction::SetTrue)]
+        dynamic: bool,
     },
     /// upgrade a single or a list of plugins.
     #[clap(arg_required_else_help = true)]

--- a/coffee_cmd/src/coffee/config.rs
+++ b/coffee_cmd/src/coffee/config.rs
@@ -1,6 +1,7 @@
 //! Coffee configuration utils.
 
 use coffee_lib::{errors::CoffeeError, plugin::Plugin};
+use log::{debug, info};
 use serde::{Deserialize, Serialize};
 use std::{env, path::Path};
 use tokio::fs::create_dir;
@@ -32,7 +33,8 @@ pub struct CoffeeConf {
 
 async fn check_dir_or_make_if_missing(path: String) -> Result<(), CoffeeError> {
     if !Path::exists(Path::new(&path.to_owned())) {
-        create_dir(path).await?;
+        create_dir(path.clone()).await?;
+        debug!("created dir {path}");
     }
     Ok(())
 }
@@ -45,6 +47,7 @@ impl CoffeeConf {
         // FIXME: check for double slash
         def_path += "/.coffee";
         check_dir_or_make_if_missing(def_path.to_string()).await?;
+        info!("creating coffee home at {def_path}");
         check_dir_or_make_if_missing(format!("{def_path}/bitcoin")).await?;
         check_dir_or_make_if_missing(format!("{def_path}/testnet")).await?;
         let mut coffee = CoffeeConf {

--- a/coffee_cmd/src/coffee/config.rs
+++ b/coffee_cmd/src/coffee/config.rs
@@ -21,6 +21,8 @@ pub struct CoffeeConf {
     /// not managed by core lightning
     /// (this file included the file managed by coffee)
     pub cln_config_path: Option<String>,
+    /// root cln directory path
+    pub cln_root: Option<String>,
     /// root path plugin manager
     pub root_path: String,
     /// all plugins that are installed
@@ -51,6 +53,7 @@ impl CoffeeConf {
             config_path: format!("{def_path}/bitcoin/coffee.conf"),
             plugins: vec![],
             cln_config_path: None,
+            cln_root: None,
         };
 
         // check the command line arguments and bind them

--- a/coffee_cmd/src/coffee/mod.rs
+++ b/coffee_cmd/src/coffee/mod.rs
@@ -125,11 +125,13 @@ impl CoffeeManager {
         Ok(())
     }
 
-    pub async fn setup_with_cln(&mut self, cln_conf_path: &str) -> Result<(), CoffeeError> {
+    pub async fn setup_with_cln(&mut self, cln_dir: &str) -> Result<(), CoffeeError> {
         if !self.cln_config.is_none() {
             warn!("you are ovveriding the previous set up");
         }
-        self.config.cln_config_path = Some(cln_conf_path.to_owned());
+        let path_with_network = format!("{cln_dir}/{}/config", self.config.network);
+        info!("configure coffe in the following cln config {path_with_network}");
+        self.config.cln_config_path = Some(path_with_network);
         self.load_cln_conf().await?;
         let mut conf = self.cln_config.clone().unwrap();
         conf.add_subconf(self.coffe_cln_config.clone())
@@ -186,8 +188,8 @@ impl PluginManager for CoffeeManager {
         Ok(())
     }
 
-    async fn setup(&mut self, cln_conf_path: &str) -> Result<(), CoffeeError> {
-        self.setup_with_cln(cln_conf_path).await?;
+    async fn setup(&mut self, cln_dir: &str) -> Result<(), CoffeeError> {
+        self.setup_with_cln(cln_dir).await?;
         self.storage.store(&self.storage_info()).await
     }
 

--- a/coffee_cmd/src/main.rs
+++ b/coffee_cmd/src/main.rs
@@ -15,7 +15,11 @@ async fn main() -> Result<(), CoffeeError> {
     let args = CoffeeArgs::parse();
     let mut coffee = CoffeeManager::new(&args).await?;
     let result = match args.command {
-        CoffeeCommand::Install { plugin, verbose } => coffee.install(&plugin, verbose).await,
+        CoffeeCommand::Install {
+            plugin,
+            verbose,
+            dynamic,
+        } => coffee.install(&plugin, verbose, dynamic).await,
         CoffeeCommand::Remove => todo!(),
         CoffeeCommand::List => coffee.list().await,
         CoffeeCommand::Upgrade => coffee.upgrade(&[""]).await,

--- a/coffee_lib/src/plugin_manager.rs
+++ b/coffee_lib/src/plugin_manager.rs
@@ -11,7 +11,12 @@ pub trait PluginManager {
     async fn configure(&mut self) -> Result<(), CoffeeError>;
 
     /// install a plugin by name, return an error if some error happens.
-    async fn install(&mut self, plugins: &str, verbose: bool) -> Result<(), CoffeeError>;
+    async fn install(
+        &mut self,
+        plugins: &str,
+        verbose: bool,
+        try_dynamic: bool,
+    ) -> Result<(), CoffeeError>;
 
     /// return the list of plugin manager by the plugin manager.
     async fn list(&mut self) -> Result<(), CoffeeError>;


### PR DESCRIPTION
Fixes https://github.com/coffee-tools/coffee/issues/66
Fixes https://github.com/coffee-tools/coffee/issues/36

this PR allow to add a plugin dynamically and skipping the configuration file

```
RUST_LOG=info cargo run -- --network testnet setup /run/media/vincent/VincentSSD/.lightning
RUST_LOG=info cargo run -- --network testnet install summary --verbose --dynamic
```

Please note that now the setup take the core lightning root directory