### PR TITLE
feat: allow to run the plugin in a dynamic way

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ dependencies = [
  "env_logger",
  "log",
  "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/coffee_cmd/Cargo.toml
+++ b/coffee_cmd/Cargo.toml
@@ -14,5 +14,6 @@ log = "0.4.17"
 env_logger = "0.9.3"
 coffee_storage = { path = "../coffee_storage"  }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
 clightningrpc-conf = "0.0.1"
 clightningrpc-common = "0.3.0-beta.3"

--- a/coffee_cmd/src/coffee/cmd.rs
+++ b/coffee_cmd/src/coffee/cmd.rs
@@ -12,6 +12,8 @@ pub struct CoffeeArgs {
     pub conf: Option<String>,
     #[clap(short, long, value_parser)]
     pub network: Option<String>,
+    #[clap(short, long, value_parser, name = "data-dir")]
+    pub data_dir: Option<String>,
 }
 
 /// Coffee subcommand of the command line daemon.

--- a/coffee_cmd/src/coffee/config.rs
+++ b/coffee_cmd/src/coffee/config.rs
@@ -44,6 +44,10 @@ impl CoffeeConf {
     pub async fn new(conf: &CoffeeArgs) -> Result<Self, CoffeeError> {
         #[allow(deprecated)]
         let mut def_path = env::home_dir().unwrap().to_str().unwrap().to_string();
+        if let Some(data_dir) = &conf.data_dir {
+            def_path = data_dir.to_owned();
+        }
+
         // FIXME: check for double slash
         def_path += "/.coffee";
         check_dir_or_make_if_missing(def_path.to_string()).await?;
@@ -62,6 +66,7 @@ impl CoffeeConf {
         // check the command line arguments and bind them
         // inside the coffee conf
         coffee.bind_cmd_line_params(&conf)?;
+
         // after we know all the information regarding
         // the configuration we try to see if there is
         // something stored already to the disk.


### PR DESCRIPTION
Fixes https://github.com/coffee-tools/coffee/issues/68

Now the command accept also `--data-dir=/tmp`

an example of command is

```
RUST_LOG=info cargo run -- --network testnet --data-dir=/tmp install summary --dynamic
```