### PR TITLE
feat(core): add remove remote command

### DIFF
--- a/coffee_cmd/src/cmd.rs
+++ b/coffee_cmd/src/cmd.rs
@@ -55,7 +55,7 @@ pub enum CoffeeCommand {
 #[derive(Debug, Subcommand)]
 pub enum RemoteAction {
     Add { name: String, url: String },
-    Remove { name: String },
+    Rm { name: String },
 }
 
 impl From<&CoffeeCommand> for coffee_core::CoffeeOperation {
@@ -79,7 +79,7 @@ impl From<&RemoteAction> for coffee_core::RemoteAction {
     fn from(value: &RemoteAction) -> Self {
         match value {
             RemoteAction::Add { name, url } => Self::Add(name.to_owned(), url.to_owned()),
-            RemoteAction::Remove { name } => Self::Remove(name.to_owned()),
+            RemoteAction::Rm { name } => Self::Rm(name.to_owned()),
         }
     }
 }

--- a/coffee_cmd/src/main.rs
+++ b/coffee_cmd/src/main.rs
@@ -31,6 +31,8 @@ async fn main() -> Result<(), CoffeeError> {
         CoffeeCommand::Remote { action } => {
             if let RemoteAction::Add { name, url } = action {
                 coffee.add_remote(name.as_str(), url.as_str()).await
+            } else if let RemoteAction::Rm { name } = action {
+                coffee.rm_remote(name.as_str()).await
             } else {
                 Err(CoffeeError::new(1, "unsupported command"))
             }

--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_json::Value;
 use std::fmt::Debug;
+use std::fs;
 use std::vec::Vec;
 
 use super::config;
@@ -278,6 +279,21 @@ impl PluginManager for CoffeeManager {
         repo.init().await?;
         self.repos.push(Box::new(repo));
         debug!("remote added: {} {}", name, &url.url_string);
+        self.storage.store(&self.storage_info()).await?;
+        Ok(())
+    }
+
+    async fn rm_remote(&mut self, name: &str) -> Result<(), CoffeeError> {
+        debug!("remote removing: {}", name);
+        let index = self
+            .repos
+            .iter()
+            .position(|x| &*x.to_owned().name() == name)
+            .unwrap();
+        let repo_path = &self.repos[index].url().path_string;
+        fs::remove_dir_all(repo_path)?;
+        self.repos.remove(index);
+        debug!("remote removed: {}", name);
         self.storage.store(&self.storage_info()).await?;
         Ok(())
     }

--- a/coffee_core/src/lib.rs
+++ b/coffee_core/src/lib.rs
@@ -18,7 +18,7 @@ pub enum CoffeeOperation {
 #[derive(Clone, Debug)]
 pub enum RemoteAction {
     Add(String, String),
-    Remove(String),
+    Rm(String),
 }
 
 pub trait CoffeeArgs {

--- a/coffee_lib/src/plugin_manager.rs
+++ b/coffee_lib/src/plugin_manager.rs
@@ -28,6 +28,9 @@ pub trait PluginManager {
     /// add the remote repository to the plugin manager.
     async fn add_remote(&mut self, name: &str, url: &str) -> Result<(), CoffeeError>;
 
+    /// remove the remote repository from the plugin manager.
+    async fn rm_remote(&mut self, name: &str) -> Result<(), CoffeeError>;
+
     /// set up the core lightning configuration target for the
     /// plugin manager.
     async fn setup(&mut self, cln_conf_path: &str) -> Result<(), CoffeeError>;

--- a/docs/docs-book/src/using-coffee.md
+++ b/docs/docs-book/src/using-coffee.md
@@ -54,10 +54,10 @@ coffee remote add <name repository> <url repository>
 
 To remove a plugin repository, simply run the following command.
 
-> ⚠️  this feature is under development, see [the tracking issue](https://github.com/coffee-tools/coffee/issues/13)
+> ✅ Implemented
 
 ```bash
-coffee remote remove <NAME_OF_THE_REPOSITORY>
+coffee remote rm <NAME_OF_THE_REPOSITORY>
 ```
 
 ## Install a Plugin


### PR DESCRIPTION
running `cargo run -- remote remove <repo name>` will: 
- remove the directory from local storage
- update the JSON file with the dump of coffee status

This is related to #13 