### PR TITLE
fix: Update installation command for btcli4j

### DIFF
--- a/docs/docs-book/src/introduction.md
+++ b/docs/docs-book/src/introduction.md
@@ -39,7 +39,7 @@ commands after you [install it](./install-coffee.md)
 ```bash
 coffee --network testnet setup /home/alice/.lightning
 coffee --network testnet remote add lightningd https://github.com/lightningd/plugins.git
-coffee --network install btcli4j
+coffee --network testnet install btcli4j
 ```
 
 >The plugin manager is currently under development, so some of the plugins can


### PR DESCRIPTION
The current installation command for btcli4j on the testnet network is incorrect and does not work as expected. This commit updates the command to use 'coffee --network testnet install btcli4j' which installs the package correctly.