### PR TITLE
fix(github): make path the executable path not the root path

### DIFF
--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -319,7 +319,7 @@ impl PluginManager for CoffeeManager {
         for repo in &self.repos {
             if let Some(plugin) = repo.get_plugin_by_name(plugin) {
                 // FIXME: there are more README file options?
-                let readme_path = format!("{}/README.md", plugin.path);
+                let readme_path = format!("{}/README.md", plugin.root_path);
                 let contents = fs::read_to_string(readme_path)?;
                 return Ok(json!({ "show": contents }));
             }

--- a/coffee_lib/src/cln_conf.rs
+++ b/coffee_lib/src/cln_conf.rs
@@ -23,7 +23,7 @@ impl CLNConf {
 
 impl Display for CLNConf {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut conf_str = "# reckless configuration\n".to_owned();
+        let mut conf_str = "# coffee configuration\n".to_owned();
         for plugin in &self.plugins {
             conf_str += format!("plugin={}\n", plugin.path).as_str();
         }

--- a/coffee_lib/src/utils.rs
+++ b/coffee_lib/src/utils.rs
@@ -4,13 +4,13 @@ use std::path::Path;
 pub fn get_plugin_info_from_path(path: &Path) -> Result<(String, String), CoffeeError> {
     match path.parent() {
         Some(parent_path) => {
-            let path_to_plugin = parent_path.to_path_buf().to_string_lossy().to_string();
+            let root_path = parent_path.to_path_buf().to_string_lossy().to_string();
             let plugin_name = parent_path
                 .file_name()
                 .unwrap()
                 .to_string_lossy()
                 .to_string();
-            Ok((path_to_plugin, plugin_name))
+            Ok((root_path, plugin_name))
         }
         None => Err(CoffeeError::new(1, "Incorrect path")),
     }


### PR DESCRIPTION
This PR fixes an issue with the `path` trait of the `plugin` struct where it stores the root path instead of the executable path of the plugin.
It mainly modifies the code of `index_repository` function to store the right information.