### PR TITLE
feat(cmd): use the radicle_term to build a nice TUI

### DIFF
--- a/coffee_cmd/src/coffee_term.rs
+++ b/coffee_cmd/src/coffee_term.rs
@@ -1,0 +1,3 @@
+mod command_show;
+
+pub use command_show::*;

--- a/coffee_cmd/src/coffee_term/command_show.rs
+++ b/coffee_cmd/src/coffee_term/command_show.rs
@@ -1,0 +1,80 @@
+//! Implementing the code function to show
+//! the command result on the terminal!
+
+use radicle_term as term;
+use radicle_term::table::TableOptions;
+
+use coffee_lib::error;
+use coffee_lib::errors::CoffeeError;
+use coffee_lib::types::{CoffeeList, CoffeeRemote};
+use term::Element;
+
+pub fn show_list(coffee_list: Result<CoffeeList, CoffeeError>) -> Result<(), CoffeeError> {
+    let remotes = coffee_list?;
+
+    term::println(
+        term::format::tertiary_bold("●"),
+        term::format::tertiary("Plugin installed"),
+    );
+    let mut table = radicle_term::Table::new(TableOptions::bordered());
+    table.push([
+        term::format::dim(String::from("●")),
+        term::format::bold(String::from("Language")),
+        term::format::bold(String::from("Name")),
+        term::format::bold(String::from("Exec path")),
+    ]);
+    table.divider();
+
+    for plugin in &remotes.plugins {
+        table.push([
+            term::format::positive("●").into(),
+            term::format::highlight(plugin.lang.to_string()),
+            term::format::bold(plugin.name()),
+            term::format::highlight(plugin.exec_path.to_owned()),
+        ])
+    }
+    table.print();
+
+    if let Some(repositories) = remotes.remotes {
+        term::blank();
+        let remotes = CoffeeRemote {
+            remotes: Some(repositories),
+        };
+        show_remote_list(Ok(remotes))?;
+    }
+
+    Ok(())
+}
+
+pub fn show_remote_list(remote_list: Result<CoffeeRemote, CoffeeError>) -> Result<(), CoffeeError> {
+    let repositories = remote_list?.remotes;
+
+    let Some(repositories) = repositories else {
+        return Err(error!("the repository is empty"));
+    };
+
+    term::println(
+        term::format::tertiary_bold("●"),
+        term::format::tertiary("List of repositories"),
+    );
+    let mut table = radicle_term::Table::new(TableOptions::bordered());
+    table.push([
+        term::format::dim(String::from("●")),
+        term::format::bold(String::from("Repository Alias")),
+        term::format::bold(String::from("URL")),
+        term::format::bold(String::from("N. Plugins")),
+    ]);
+    table.divider();
+
+    for repository in &repositories {
+        table.push([
+            term::format::positive("●").into(),
+            term::format::highlight(repository.local_name.to_owned()),
+            term::format::bold(repository.url.to_owned()),
+            term::format::highlight(repository.plugins.len().to_string()),
+        ])
+    }
+    table.print();
+
+    Ok(())
+}

--- a/coffee_cmd/src/term.rs
+++ b/coffee_cmd/src/term.rs
@@ -1,0 +1,1 @@
+mod command_show;

--- a/coffee_cmd/src/term/command_show.rs
+++ b/coffee_cmd/src/term/command_show.rs
@@ -1,0 +1,10 @@
+//! Implementing the code function to show
+//! the command result on the terminal!
+use serde_json::Value;
+
+
+pub fn show_remotes(remotes: Result<Value>) -> Result<(), CoffeeError> {
+    let remotes = remotes?;
+    radicle_term::format::bold(serde_json::to_string_pretty(remotes).unwrap());
+    Ok(())
+}

--- a/coffee_lib/src/lib.rs
+++ b/coffee_lib/src/lib.rs
@@ -11,5 +11,6 @@ pub mod plugin;
 pub mod plugin_conf;
 pub mod plugin_manager;
 pub mod repository;
+pub mod types;
 pub mod url;
 pub mod utils;

--- a/coffee_lib/src/plugin.rs
+++ b/coffee_lib/src/plugin.rs
@@ -1,6 +1,6 @@
 //! Plugin module that abstract the concept of a cln plugin
 //! from a plugin manager point of view.
-use std::fmt;
+use std::fmt::{self, Display};
 
 use log::debug;
 use serde::{Deserialize, Serialize};
@@ -23,6 +23,22 @@ pub enum PluginLang {
     JavaScript,
     TypeScript,
     Unknown,
+}
+
+impl Display for PluginLang {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let lang = match self {
+            PluginLang::PyPip | PluginLang::PyPoetry => "python",
+            PluginLang::JavaScript => "javascript",
+            PluginLang::Rust => "rust",
+            PluginLang::Dart => "dart",
+            PluginLang::Go => "go",
+            PluginLang::JVM => "jvm",
+            PluginLang::TypeScript => "typescrip",
+            PluginLang::Unknown => "unknown",
+        };
+        write!(f, "{lang}")
+    }
 }
 
 impl PluginLang {
@@ -84,7 +100,7 @@ pub struct Plugin {
     pub root_path: String,
     /// path of the main file
     pub exec_path: String,
-    lang: PluginLang,
+    pub lang: PluginLang,
     conf: Option<Conf>,
 }
 

--- a/coffee_lib/src/plugin_manager.rs
+++ b/coffee_lib/src/plugin_manager.rs
@@ -2,7 +2,10 @@
 use async_trait::async_trait;
 use serde_json::Value;
 
-use crate::errors::CoffeeError;
+use crate::{
+    errors::CoffeeError,
+    types::{CoffeeList, CoffeeRemote},
+};
 
 /// Plugin manager traits that define the API a generic
 /// plugin manager.
@@ -20,7 +23,7 @@ pub trait PluginManager {
     ) -> Result<(), CoffeeError>;
 
     /// return the list of plugins installed by the plugin manager.
-    async fn list(&mut self, remotes: bool) -> Result<Value, CoffeeError>;
+    async fn list(&mut self, remotes: bool) -> Result<CoffeeList, CoffeeError>;
 
     /// upgrade a sequence of plugin managed by the plugin manager.
     async fn upgrade(&mut self, plugins: &[&str]) -> Result<(), CoffeeError>;
@@ -32,7 +35,7 @@ pub trait PluginManager {
     async fn rm_remote(&mut self, name: &str) -> Result<(), CoffeeError>;
 
     /// list the remote repositories for the plugin manager.
-    async fn list_remotes(&mut self) -> Result<Value, CoffeeError>;
+    async fn list_remotes(&mut self) -> Result<CoffeeRemote, CoffeeError>;
 
     /// set up the core lightning configuration target for the
     /// plugin manager.

--- a/coffee_lib/src/types/mod.rs
+++ b/coffee_lib/src/types/mod.rs
@@ -1,0 +1,22 @@
+//! Coffee Model Definition
+use serde::{Deserialize, Serialize};
+
+use crate::plugin::Plugin;
+
+#[derive(Serialize, Deserialize)]
+pub struct CoffeeList {
+    pub remotes: Option<Vec<CoffeeListRemote>>,
+    pub plugins: Vec<Plugin>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CoffeeRemote {
+    pub remotes: Option<Vec<CoffeeListRemote>>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CoffeeListRemote {
+    pub local_name: String,
+    pub url: String,
+    pub plugins: Vec<Plugin>,
+}


### PR DESCRIPTION
radicle_term is pretty good to build a couple of UI component in the terminal,

for example the `coffee list --remotes` has the following result on my system

```
➜  coffee git:(macros/termianl-ui) cargo run --bin coffee -- --network testnet remote list

    Finished dev [unoptimized + debuginfo] target(s) in 0.18s
     Running `target/debug/coffee --network testnet remote list`
● List of repositories
╭─────────────────────────────────────────────────────────────────────────────╮
│ ●   Repository Alias   URL                                       N. Plugins │
├─────────────────────────────────────────────────────────────────────────────┤
│ ●   folgore-git        https://github.com/coffee-tools/folgore   1          │
│ ●   lightningd         https://github.com/lightningd/plugins     27         │
│ ●   lightningd         https://github.com/lightningd/plugins     27         │
╰─────────────────────────────────────────────────────────────────────────────╯


```