### PR TITLE
fix(cmd): fix the path derived from the config file

### DIFF
--- a/coffee_github/src/repository.rs
+++ b/coffee_github/src/repository.rs
@@ -103,7 +103,7 @@ impl Github {
                                 }
                             };
 
-                            exec_path = Some(format!("{root_path}/{}", conf_file.plugin.name));
+                            exec_path = Some(format!("{root_path}/{}", conf_file.plugin.main));
                             conf = Some(conf_file);
                             break;
                         }


### PR DESCRIPTION
when we read from config of the plugin we should
build the path with `{root_path}/{main}` and not
the `{root}/{name}`.