### PR TITLE
fix(coffee): don't allow duplicate repositories 

### DIFF
--- a/coffee_cmd/src/cmd.rs
+++ b/coffee_cmd/src/cmd.rs
@@ -50,6 +50,9 @@ pub enum CoffeeCommand {
     /// show the README file of the plugin
     #[clap(arg_required_else_help = true)]
     Show { plugin: String },
+    /// clean up remote repositories storage information
+    #[clap(arg_required_else_help = false)]
+    Nurse {},
 }
 
 #[derive(Debug, Subcommand)]
@@ -73,6 +76,7 @@ impl From<&CoffeeCommand> for coffee_core::CoffeeOperation {
             CoffeeCommand::Remote { action } => Self::Remote(action.into()),
             CoffeeCommand::Remove { plugin } => Self::Remove(plugin.to_owned()),
             CoffeeCommand::Show { plugin } => Self::Show(plugin.to_owned()),
+            CoffeeCommand::Nurse {} => Self::Nurse,
         }
     }
 }

--- a/coffee_core/src/lib.rs
+++ b/coffee_core/src/lib.rs
@@ -14,6 +14,7 @@ pub enum CoffeeOperation {
     /// Setup(core lightning root path)
     Setup(String),
     Show(String),
+    Nurse,
 }
 
 #[derive(Clone, Debug)]

--- a/coffee_lib/src/plugin_manager.rs
+++ b/coffee_lib/src/plugin_manager.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::{
     errors::CoffeeError,
-    types::{CoffeeList, CoffeeRemote, CoffeeRemove},
+    types::{CoffeeList, CoffeeNurse, CoffeeRemote, CoffeeRemove},
 };
 
 /// Plugin manager traits that define the API a generic
@@ -31,6 +31,9 @@ pub trait PluginManager {
     /// upgrade a sequence of plugin managed by the plugin manager.
     async fn upgrade(&mut self, plugins: &[&str]) -> Result<(), CoffeeError>;
 
+    /// refresh the storage information about the remote repositories of the plugin manager.
+    async fn remote_sync(&mut self) -> Result<(), CoffeeError>;
+
     /// add the remote repository to the plugin manager.
     async fn add_remote(&mut self, name: &str, url: &str) -> Result<(), CoffeeError>;
 
@@ -46,4 +49,7 @@ pub trait PluginManager {
 
     /// show the README file of the pulgin
     async fn show(&mut self, plugin: &str) -> Result<Value, CoffeeError>;
+
+    /// clean up storage information about the remote repositories of the plugin manager.
+    async fn nurse(&mut self) -> Result<CoffeeNurse, CoffeeError>;
 }

--- a/coffee_lib/src/types/mod.rs
+++ b/coffee_lib/src/types/mod.rs
@@ -24,3 +24,14 @@ pub struct CoffeeListRemote {
     pub url: String,
     pub plugins: Vec<Plugin>,
 }
+
+#[derive(Serialize, Deserialize)]
+pub enum NurseStatus {
+    Corrupted,
+    Sane,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CoffeeNurse {
+    pub status: NurseStatus,
+}

--- a/docs/docs-book/src/using-coffee.md
+++ b/docs/docs-book/src/using-coffee.md
@@ -130,3 +130,11 @@ coffee list
 ```bash
 coffee show <plugin_name>
 ```
+
+## To fix corrupt remote repositories local clones
+
+> ✅ Implemented
+
+```bash
+coffee nurse
+```


### PR DESCRIPTION
- added a hashset of the remote repositories names to the storage information of coffee on disk (JSON)
- added a function to check if the remote repository clone was deleted from disk manually and called it when needed