### PR TITLE
feat(coffee): implement upgrade command

### DIFF
--- a/coffee_cmd/src/cmd.rs
+++ b/coffee_cmd/src/cmd.rs
@@ -28,9 +28,9 @@ pub enum CoffeeCommand {
         #[arg(short, long, action = clap::ArgAction::SetTrue)]
         dynamic: bool,
     },
-    /// upgrade a single or a list of plugins.
+    /// upgrade a single repository.
     #[clap(arg_required_else_help = true)]
-    Upgrade,
+    Upgrade { repo: String },
     /// Print the list of plugins installed in cln.
     #[clap(arg_required_else_help = false)]
     List {},
@@ -70,7 +70,7 @@ impl From<&CoffeeCommand> for coffee_core::CoffeeOperation {
                 verbose,
                 dynamic,
             } => Self::Install(plugin.to_owned(), *verbose, *dynamic),
-            CoffeeCommand::Upgrade => Self::Upgrade,
+            CoffeeCommand::Upgrade { repo } => Self::Upgrade(repo.to_owned()),
             CoffeeCommand::List {} => Self::List,
             CoffeeCommand::Setup { cln_conf } => Self::Setup(cln_conf.to_owned()),
             CoffeeCommand::Remote { action } => Self::Remote(action.into()),

--- a/coffee_core/src/lib.rs
+++ b/coffee_core/src/lib.rs
@@ -7,7 +7,8 @@ pub enum CoffeeOperation {
     Install(String, bool, bool),
     /// List(include remotes)
     List,
-    Upgrade,
+    // Upgrade(name of the repository)
+    Upgrade(String),
     Remove(String),
     /// Remote(name repository, url of the repositoryu)
     Remote(RemoteAction),

--- a/coffee_github/src/utils.rs
+++ b/coffee_github/src/utils.rs
@@ -2,6 +2,8 @@ use coffee_lib::errors::CoffeeError;
 use coffee_lib::url::URL;
 use log::debug;
 
+use coffee_lib::types::UpgradeStatus;
+
 pub async fn clone_recursive_fix(repo: git2::Repository, url: &URL) -> Result<(), CoffeeError> {
     let repository = repo.submodules().unwrap_or_default();
     debug!("submodule count: {}", repository.len());
@@ -19,4 +21,51 @@ pub async fn clone_recursive_fix(repo: git2::Repository, url: &URL) -> Result<()
         }?;
     }
     Ok(())
+}
+
+pub fn fast_forward(path: &str, branch: &str) -> Result<UpgradeStatus, CoffeeError> {
+    let repo = git2::Repository::open(path).map_err(|err| CoffeeError::new(1, err.message()))?;
+
+    repo.find_remote("origin")
+        .map_err(|err| CoffeeError::new(1, err.message()))?
+        .fetch(&[branch], None, None)
+        .map_err(|err| CoffeeError::new(1, err.message()))?;
+
+    let fetch_head = repo
+        .find_reference("FETCH_HEAD")
+        .map_err(|err| CoffeeError::new(1, err.message()))?;
+
+    let fetch_commit = repo
+        .reference_to_annotated_commit(&fetch_head)
+        .map_err(|err| CoffeeError::new(1, err.message()))?;
+
+    let analysis = repo
+        .merge_analysis(&[&fetch_commit])
+        .map_err(|err| CoffeeError::new(1, err.message()))?;
+
+    if analysis.0.is_up_to_date() {
+        Ok(UpgradeStatus::UpToDate)
+    } else if analysis.0.is_fast_forward() {
+        let refname = format!("refs/heads/{}", branch);
+        let mut reference = repo
+            .find_reference(&refname)
+            .map_err(|err| CoffeeError::new(1, err.message()))?;
+
+        reference
+            .set_target(fetch_commit.id(), "Fast-Forward")
+            .map_err(|err| CoffeeError::new(1, err.message()))?;
+
+        repo.set_head(&refname)
+            .map_err(|err| CoffeeError::new(1, err.message()))?;
+
+        match repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force())) {
+            Ok(()) => return Ok(UpgradeStatus::Updated),
+            Err(err) => return Err(CoffeeError::new(1, err.message())),
+        }
+    } else {
+        Err(CoffeeError::new(
+            1,
+            "Error trying to pull the latest changes",
+        ))
+    }
 }

--- a/coffee_lib/src/plugin_manager.rs
+++ b/coffee_lib/src/plugin_manager.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::{
     errors::CoffeeError,
-    types::{CoffeeList, CoffeeNurse, CoffeeRemote, CoffeeRemove},
+    types::{CoffeeList, CoffeeNurse, CoffeeRemote, CoffeeRemove, CoffeeUpgrade},
 };
 
 /// Plugin manager traits that define the API a generic
@@ -28,8 +28,8 @@ pub trait PluginManager {
     /// return the list of plugins installed by the plugin manager.
     async fn list(&mut self) -> Result<CoffeeList, CoffeeError>;
 
-    /// upgrade a sequence of plugin managed by the plugin manager.
-    async fn upgrade(&mut self, plugins: &[&str]) -> Result<(), CoffeeError>;
+    /// upgrade a single or multiple repositories.
+    async fn upgrade(&mut self, repo: &str) -> Result<CoffeeUpgrade, CoffeeError>;
 
     /// refresh the storage information about the remote repositories of the plugin manager.
     async fn remote_sync(&mut self) -> Result<(), CoffeeError>;

--- a/coffee_lib/src/repository.rs
+++ b/coffee_lib/src/repository.rs
@@ -6,6 +6,8 @@ use crate::errors::CoffeeError;
 use crate::plugin::Plugin;
 use crate::url::URL;
 
+use crate::types::CoffeeUpgrade;
+
 use async_trait::async_trait;
 
 #[async_trait]
@@ -21,6 +23,9 @@ pub trait Repository: Any {
 
     /// return the list of plugin that are register contained inside the repository.
     async fn list(&self) -> Result<Vec<Plugin>, CoffeeError>;
+
+    /// upgrade the repository
+    async fn upgrade(&self, plugins: &Vec<Plugin>) -> Result<CoffeeUpgrade, CoffeeError>;
 
     /// return the name of the repository.
     fn name(&self) -> String;

--- a/coffee_lib/src/types/mod.rs
+++ b/coffee_lib/src/types/mod.rs
@@ -35,3 +35,19 @@ pub enum NurseStatus {
 pub struct CoffeeNurse {
     pub status: NurseStatus,
 }
+
+#[derive(Serialize, Deserialize)]
+pub enum UpgradeStatus {
+    UpToDate,
+    Updated,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CoffeeUpgrade {
+    pub repo: String,
+    pub status: UpgradeStatus,
+    /// If the status of the repository is
+    /// alterate we return the list of plugin
+    /// that are effected and need to be recompiled.
+    pub plugins_effected: Vec<String>,
+}

--- a/coffee_storage/src/model/repository.rs
+++ b/coffee_storage/src/model/repository.rs
@@ -14,4 +14,5 @@ pub struct Repository {
     pub name: String,
     pub url: URL,
     pub plugins: Vec<Plugin>,
+    pub branch: String,
 }

--- a/docs/docs-book/src/using-coffee.md
+++ b/docs/docs-book/src/using-coffee.md
@@ -107,13 +107,13 @@ coffee remove <plugin_name>
 
 ## Upgrade a Plugin
 
-> ⚠️  this feature is under development, see [the tracking issue](https://github.com/coffee-tools/coffee/issues/13)
-
 Coffee tightly integrates with git, allowing you to easily upgrade your plugins through the command line interface (CLI). This eliminates the need for tedious tasks such as downloading the latest updates and creating new versions of plugins. To upgrade a plugin, all you need to do is run.
-
+> ✅ Implemented
 ```bash
-coffee upgrade <plugin_name>
+coffee upgrade <repo_name>
 ```
+
+
 
 ## Listing all the plugins
 


### PR DESCRIPTION
Fixes #43 

-  The code implements the `upgrade` command
- Users can choose to upgrade a single repository or all repositories
- To upgrade a single repository, the user runs `coffee upgrade <repo_name>`
- To upgrade all repositories, the user runs `coffee upgrade --all`
- It is not possible to use the `all` flag with a specific repository name
- The `upgrade` function returns a `CoffeeUpgrade` object indicating whether the local clone is up to date or not
- A new field called `branch` has been added to the repository structure
- This field accounts for the situation where the main branch is referred to as `master`
- The `branch` field will facilitate future work on issue #131.






