### PR TITLE
feat(httpd): implement list call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,9 +490,12 @@ dependencies = [
  "actix-web",
  "clap",
  "coffee_core",
+ "coffee_lib",
  "env_logger",
  "log",
  "paperclip",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/coffee_httpd/Cargo.toml
+++ b/coffee_httpd/Cargo.toml
@@ -6,7 +6,10 @@ edition = "2021"
 [dependencies]
 actix-web = "4"
 clap = "4.1.11"
+tokio = { version = "1.22.0", features = ["sync"] }
 coffee_core = { path = "../coffee_core" }
+coffee_lib = { path = "../coffee_lib" }
 paperclip = { version = "0.8.0", features = ["actix4"] }
 log = "0.4.17"
 env_logger = "0.9.3"
+serde_json = "1"


### PR DESCRIPTION
- Added a new function coffee_list to handle the `/list` endpoint.
- The function takes the data parameter of type `web::Data<AppState>` to access the shared state.
- The function doesn't take any body

This is the response from the server for this call
<img width="659" alt="image" src="https://github.com/coffee-tools/coffee/assets/60650661/bf929fe1-61f7-44d2-a74d-a4f191589604">