### PR TITLE
feat(httpd): implement remote endpoint

### DIFF
--- a/coffee_httpd/src/httpd/server.rs
+++ b/coffee_httpd/src/httpd/server.rs
@@ -97,8 +97,12 @@ async fn coffee_remote_add(
     data: web::Data<AppState>,
     body: Json<HashMap<String, String>>,
 ) -> Result<HttpResponse, Error> {
-    let repository_name = body.get("repository_name").unwrap();
-    let repository_url = body.get("repository_url").unwrap();
+    let repository_name = body.get("repository_name").ok_or_else(|| {
+        actix_web::error::ErrorBadRequest("Missing 'repository_name' field in the request body")
+    })?;
+    let repository_url = body.get("repository_url").ok_or_else(|| {
+        actix_web::error::ErrorBadRequest("Missing 'repository_url' field in the request body")
+    })?;
 
     let mut coffee = data.coffee.lock().await;
     let result = coffee.add_remote(repository_name, repository_url).await;
@@ -120,7 +124,9 @@ async fn coffee_remote_rm(
     data: web::Data<AppState>,
     body: Json<HashMap<String, String>>,
 ) -> Result<HttpResponse, Error> {
-    let repository_name = body.get("repository_name").unwrap();
+    let repository_name = body.get("repository_name").ok_or_else(|| {
+        actix_web::error::ErrorBadRequest("Missing 'repository_name' field in the request body")
+    })?;
 
     let mut coffee = data.coffee.lock().await;
     let result = coffee.rm_remote(repository_name).await;


### PR DESCRIPTION
This pull request adds three new endpoints:

-  `coffee_remote_add`  This endpoint handles the addition of a remote repository. It expects a POST request with a JSON body containing the `repository_name` and `repository_url` parameters. 

- `coffee_remote_rm`  This endpoint handles the removal of a remote repository. It expects a POST request with a JSON body containing the `repository_name` parameter. 

- `coffee_remote_list` This endpoint handles the retrieval of the list of remote repositories. It expects a GET request and returns a JSON object.

To test the new endpoints: 
- 
-
```
curl -X 'POST' \
  'http://localhost:8080/remote/add' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "repository_name": "Folgore",
  "repository_url": "https://github.com/coffee-tools/folgore"
}'
```
- 
```
curl -X 'POST' \
  'http://localhost:8080/remote/rm' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "repository_name": "Folgore"
}'
```
-
```
curl http://localhost:8080/remote/list
```