### PR TITLE
fix(lib): report the error when the command fails

### DIFF
--- a/coffee_lib/src/macros.rs
+++ b/coffee_lib/src/macros.rs
@@ -24,14 +24,20 @@ macro_rules! sh {
             let mut cmd = Command::new(command);
             cmd.args(&cmd_tok[1..cmd_tok.len()]);
             cmd.current_dir($root);
-            if $verbose {
-                let _ = cmd
-                    .spawn()
+            let command = if $verbose {
+                cmd.spawn()
                     .expect("Unable to run the command")
-                    .wait()
-                    .await?;
+                    .wait_with_output()
+                    .await?
             } else {
-                let _ = cmd.output().await?;
+                cmd.output().await?
+            };
+
+            if !command.status.success() {
+                return Err(CoffeeError::new(
+                    2,
+                    &String::from_utf8(command.stderr).unwrap(),
+                ));
             }
         }
     };


### PR DESCRIPTION
We was usul to return Ok when a command fails because we was ignoring the command result.

With this commit now we are able to report the error to the user.

Fixes https://github.com/coffee-tools/coffee/issues/146