### PR TITLE
Refactor configuration handling to preserve user-defined setting

### DIFF
--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -102,9 +102,6 @@ impl CoffeeManager {
             log::info!("storage file do not exist");
             return Ok(());
         };
-        // this is really needed? I think no, because coffee at this point
-        // have a new conf loading
-        self.config = store.config;
         store
             .repositories
             .iter()


### PR DESCRIPTION
Addresses #145 
Coffee does not consider the network parameter when setting up the configuration. 
Currently, the configuration is being overwritten with the stored configuration, which prevents users from setting the desired network. 

By removing the line that overwrites the configuration in the inventory function, the user will be able to explicitly set the network parameter.