### PR TITLE
fix(core): create repositories folder when configuring coffee

### DIFF
--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -300,7 +300,9 @@ impl PluginManager for CoffeeManager {
     async fn remote_sync(&mut self) -> Result<(), CoffeeError> {
         // check if there are any unrelated files or folders in the `repositories` folder
         let repos_path = PathBuf::from(format!("{}/repositories/", self.config.root_path));
-        let mut dir_entries = fs::read_dir(repos_path).await?;
+        let mut dir_entries = fs::read_dir(repos_path)
+            .await
+            .map_err(|_| CoffeeError::new(1, "`repositories` folder wasn't found"))?;
         while let Some(entry) = dir_entries.next_entry().await? {
             let entry_name = entry.file_name().to_string_lossy().to_string();
             if !self.repos.contains_key(&entry_name) {

--- a/coffee_core/src/config.rs
+++ b/coffee_core/src/config.rs
@@ -52,6 +52,7 @@ impl CoffeeConf {
         info!("creating coffee home at {def_path}");
         check_dir_or_make_if_missing(format!("{def_path}/bitcoin")).await?;
         check_dir_or_make_if_missing(format!("{def_path}/testnet")).await?;
+        check_dir_or_make_if_missing(format!("{def_path}/repositories")).await?;
         let mut coffee = CoffeeConf {
             network: "bitcoin".to_owned(),
             root_path: def_path.to_string(),


### PR DESCRIPTION
Fixes #151

So this is a double solution to make sure the issue is solved.
1- we create the `repositories` folder beforehand along with the `bitcoin` and `testnet` folders. 
- This by itself should solve the issue.

2- we provide a proper error message to the user if the folder is missing.