### PR TITLE
feat(httpd): implement install and remove enpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,6 +669,7 @@ dependencies = [
  "env_logger",
  "log",
  "paperclip",
+ "serde",
  "serde_json",
  "tokio",
 ]
@@ -681,6 +682,7 @@ dependencies = [
  "env_logger",
  "git2",
  "log",
+ "paperclip",
  "serde",
  "serde_json",
  "tokio",

--- a/coffee_cmd/src/coffee_term/command_show.rs
+++ b/coffee_cmd/src/coffee_term/command_show.rs
@@ -6,7 +6,7 @@ use radicle_term::table::TableOptions;
 
 use coffee_lib::error;
 use coffee_lib::errors::CoffeeError;
-use coffee_lib::types::{CoffeeList, CoffeeRemote};
+use coffee_lib::types::response::{CoffeeList, CoffeeRemote};
 use term::Element;
 
 pub fn show_list(coffee_list: Result<CoffeeList, CoffeeError>) -> Result<(), CoffeeError> {

--- a/coffee_cmd/src/main.rs
+++ b/coffee_cmd/src/main.rs
@@ -7,7 +7,7 @@ use radicle_term as term;
 use coffee_core::coffee::CoffeeManager;
 use coffee_lib::errors::CoffeeError;
 use coffee_lib::plugin_manager::PluginManager;
-use coffee_lib::types::{NurseStatus, UpgradeStatus};
+use coffee_lib::types::response::{NurseStatus, UpgradeStatus};
 
 use crate::cmd::CoffeeArgs;
 use crate::cmd::CoffeeCommand;

--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -19,7 +19,7 @@ use coffee_lib::error;
 use coffee_lib::errors::CoffeeError;
 use coffee_lib::plugin_manager::PluginManager;
 use coffee_lib::repository::Repository;
-use coffee_lib::types::*;
+use coffee_lib::types::response::*;
 use coffee_lib::url::URL;
 use coffee_storage::model::repository::{Kind, Repository as RepositoryInfo};
 use coffee_storage::storage::StorageManager;

--- a/coffee_github/src/repository.rs
+++ b/coffee_github/src/repository.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 
 use async_trait::async_trait;
-use coffee_lib::types::CoffeeUpgrade;
+use coffee_lib::types::response::CoffeeUpgrade;
 use git2;
 use log::debug;
 use tokio::fs::File;

--- a/coffee_github/src/utils.rs
+++ b/coffee_github/src/utils.rs
@@ -2,7 +2,7 @@ use coffee_lib::errors::CoffeeError;
 use coffee_lib::url::URL;
 use log::debug;
 
-use coffee_lib::types::UpgradeStatus;
+use coffee_lib::types::response::UpgradeStatus;
 
 pub async fn clone_recursive_fix(repo: git2::Repository, url: &URL) -> Result<(), CoffeeError> {
     let repository = repo.submodules().unwrap_or_default();

--- a/coffee_httpd/Cargo.toml
+++ b/coffee_httpd/Cargo.toml
@@ -16,8 +16,9 @@ actix-web = "4"
 clap = "4.1.11"
 tokio = { version = "1.22.0", features = ["sync"] }
 coffee_core = { path = "../coffee_core" }
-coffee_lib = { path = "../coffee_lib" }
+coffee_lib = { path = "../coffee_lib", features = ["open-api"] }
 paperclip = { version = "0.8.0", features = ["actix4"] }
 log = "0.4.17"
 env_logger = "0.9.3"
+serde = "1"
 serde_json = "1"

--- a/coffee_httpd/src/cmd.rs
+++ b/coffee_httpd/src/cmd.rs
@@ -11,6 +11,8 @@ pub struct HttpdArgs {
     #[clap(long, value_parser)]
     pub network: Option<String>,
     #[clap(long, value_parser)]
+    pub cln_path: String,
+    #[clap(long, value_parser)]
     pub data_dir: Option<String>,
     #[clap(long, value_parser)]
     pub host: Option<String>,

--- a/coffee_httpd/src/httpd.rs
+++ b/coffee_httpd/src/httpd.rs
@@ -1,2 +1,3 @@
 pub mod server;
 pub use server::*;
+pub mod macros;

--- a/coffee_httpd/src/httpd/macros.rs
+++ b/coffee_httpd/src/httpd/macros.rs
@@ -1,0 +1,15 @@
+/// handle_httpd_response macro is the macro that handles HTTPD responses
+#[macro_export]
+macro_rules! handle_httpd_response {
+    ($result:expr, $msg:expr) => {
+        match $result {
+            Ok(_) => Ok(HttpResponse::Ok().body(format!($msg))),
+            Err(err) => Err(actix_web::error::ErrorInternalServerError(format!(
+                "Error: {}",
+                err
+            ))),
+        }
+    };
+}
+
+pub use handle_httpd_response;

--- a/coffee_httpd/src/main.rs
+++ b/coffee_httpd/src/main.rs
@@ -1,24 +1,25 @@
 use clap::Parser;
-use log;
 
 use coffee_core::coffee::CoffeeManager;
+use coffee_lib::errors::CoffeeError;
+use coffee_lib::macros::error;
+use coffee_lib::plugin_manager::PluginManager;
 
 mod cmd;
 pub mod httpd;
 
 #[actix_web::main]
-async fn main() {
+async fn main() -> Result<(), CoffeeError> {
     env_logger::init();
     let cmd = cmd::HttpdArgs::parse();
-    let coffee = CoffeeManager::new(&cmd).await;
-    if let Err(err) = &coffee {
-        println!("{err}");
-    }
-    let coffee = coffee.unwrap();
+    let mut coffee = CoffeeManager::new(&cmd).await?;
+    coffee.setup(&cmd.cln_path).await?;
 
     let port = cmd.port.unwrap_or(8080) as u16;
     log::info!("Running on port 127.0.0.1:{port}");
     if let Err(err) = httpd::run_httpd(coffee, ("127.0.0.1", port)).await {
-        println!("{err}");
+        return Err(error!("Error while running the httpd: {err}"));
     }
+
+    Ok(())
 }

--- a/coffee_lib/Cargo.toml
+++ b/coffee_lib/Cargo.toml
@@ -11,3 +11,7 @@ git2 = "0.16.1"
 log = "0.4.17"
 env_logger = "0.9.3"
 tokio = { version = "1.22.0", features = ["process"] }
+paperclip = { version = "0.8.0", features = ["actix4"], optional = true }
+
+[features]
+open-api = ["dep:paperclip"]

--- a/coffee_lib/src/macros.rs
+++ b/coffee_lib/src/macros.rs
@@ -48,5 +48,4 @@ macro_rules! sh {
     };
 }
 
-pub use error;
-pub use sh;
+pub use {error, sh};

--- a/coffee_lib/src/plugin_manager.rs
+++ b/coffee_lib/src/plugin_manager.rs
@@ -1,7 +1,7 @@
 //! Plugin manager module definition.
 use async_trait::async_trait;
 
-use crate::{errors::CoffeeError, types::*};
+use crate::{errors::CoffeeError, types::response::*};
 
 /// Plugin manager traits that define the API a generic
 /// plugin manager.

--- a/coffee_lib/src/repository.rs
+++ b/coffee_lib/src/repository.rs
@@ -6,7 +6,7 @@ use crate::errors::CoffeeError;
 use crate::plugin::Plugin;
 use crate::url::URL;
 
-use crate::types::CoffeeUpgrade;
+use crate::types::response::CoffeeUpgrade;
 
 use async_trait::async_trait;
 

--- a/coffee_lib/src/types/mod.rs
+++ b/coffee_lib/src/types/mod.rs
@@ -1,58 +1,90 @@
 //! Coffee Model Definition
-use serde::{Deserialize, Serialize};
 
-use crate::plugin::Plugin;
+// Definition of the request types.
+pub mod request {
+    use paperclip::actix::Apiv2Schema;
+    use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct CoffeeRemove {
-    pub plugin: Plugin,
+    #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
+    pub struct Install {
+        pub plugin: String,
+        pub try_dynamic: bool,
+    }
+
+    #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
+    pub struct Remove {
+        pub plugin: String,
+    }
+
+    #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
+    pub struct RemoteAdd {
+        pub repository_name: String,
+        pub repository_url: String,
+    }
+
+    #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
+    pub struct RemoteRm {
+        pub repository_name: String,
+    }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct CoffeeList {
-    pub plugins: Vec<Plugin>,
-}
+// Definition of the response types.
+pub mod response {
+    use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CoffeeRemote {
-    pub remotes: Option<Vec<CoffeeListRemote>>,
-}
+    use crate::plugin::Plugin;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CoffeeListRemote {
-    pub local_name: String,
-    pub url: String,
-    pub plugins: Vec<Plugin>,
-}
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct CoffeeRemove {
+        pub plugin: Plugin,
+    }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub enum NurseStatus {
-    Corrupted,
-    Sane,
-}
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct CoffeeList {
+        pub plugins: Vec<Plugin>,
+    }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct CoffeeNurse {
-    pub status: NurseStatus,
-}
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct CoffeeRemote {
+        pub remotes: Option<Vec<CoffeeListRemote>>,
+    }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub enum UpgradeStatus {
-    UpToDate,
-    Updated,
-}
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct CoffeeListRemote {
+        pub local_name: String,
+        pub url: String,
+        pub plugins: Vec<Plugin>,
+    }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct CoffeeUpgrade {
-    pub repo: String,
-    pub status: UpgradeStatus,
-    /// If the status of the repository is
-    /// alterate we return the list of plugin
-    /// that are effected and need to be recompiled.
-    pub plugins_effected: Vec<String>,
-}
+    #[derive(Debug, Serialize, Deserialize)]
+    pub enum NurseStatus {
+        Corrupted,
+        Sane,
+    }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CoffeeShow {
-    pub readme: String,
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct CoffeeNurse {
+        pub status: NurseStatus,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub enum UpgradeStatus {
+        UpToDate,
+        Updated,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct CoffeeUpgrade {
+        pub repo: String,
+        pub status: UpgradeStatus,
+        /// If the status of the repository is
+        /// alterate we return the list of plugin
+        /// that are effected and need to be recompiled.
+        pub plugins_effected: Vec<String>,
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct CoffeeShow {
+        pub readme: String,
+    }
 }

--- a/docs/docs-book/src/using-coffee.md
+++ b/docs/docs-book/src/using-coffee.md
@@ -150,7 +150,7 @@ Please note that the server runs on `localhost` with port `8080` where you can f
 To start the Coffee server, run the following command:
 
  ```shell
- coffee_httpd --network <network>
+ coffee_httpd --cln-path <core_lightning_path> --network <network>  
  ```
 
 Make sure the `coffee_httpd` binary is in your system PATH or in the current working directory.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-coffee_lib = { path = "../coffee_lib" }
+coffee_lib = { path = "../coffee_lib", features = ["open-api"] }
 coffee_testing = { path = "../coffee_testing" }
 anyhow = "1.0.71"
 log = { version = "0.4", features = ["std"] }

--- a/tests/src/coffee_httpd_integration_tests.rs
+++ b/tests/src/coffee_httpd_integration_tests.rs
@@ -1,3 +1,6 @@
+use serde_json::json;
+
+use coffee_lib::types::request::*;
 use coffee_testing::cln::Node;
 use coffee_testing::CoffeeHTTPDTesting;
 
@@ -5,27 +8,62 @@ use crate::init;
 
 #[tokio::test(flavor = "multi_thread")]
 #[ntest::timeout(560000)]
-pub async fn init_httpd_add_remote() {
+pub async fn httpd_init_add_remote() {
     init();
 
     let mut cln = Node::tmp().await.unwrap();
-    let manager = CoffeeHTTPDTesting::tmp().await.unwrap();
-
     let lightning_dir = cln.rpc().getinfo().unwrap().ligthning_dir;
     let lightning_dir = lightning_dir.strip_suffix("/regtest").unwrap();
+    let manager = CoffeeHTTPDTesting::tmp(lightning_dir.to_string())
+        .await
+        .unwrap();
     log::info!("lightning path: {lightning_dir}");
-
     let url = manager.url();
     log::info!("base url: {url}");
+    let client = reqwest::Client::new();
 
-    let body = reqwest::get(format!("{url}/list"))
-        .await
-        .unwrap()
-        .text()
+    // Define the request body to be sent to the /remote/add endpoint
+    let remote_add_request = RemoteAdd {
+        repository_name: "lightningd".to_string(),
+        repository_url: "https://github.com/lightningd/plugins.git".to_string(),
+    };
+
+    // Send the request to add a remote repository
+    let response = client
+        .post(format!("{}/remote/add", url))
+        .json(&remote_add_request)
+        .send()
         .await
         .unwrap();
 
-    println!("Response body: {}", body);
+    // Check the response status code, log the body.
+    assert!(response.status().is_success());
+    let body = response.text().await.unwrap();
+    log::info!("/remote/add response: {}", body);
+
+    // Define the request body to be sent to the /install endpoint
+    let install_request = Install {
+        plugin: "summary".to_string(),
+        try_dynamic: true,
+    };
+
+    // Send the request to install a plugin
+    let response = client
+        .post(format!("{}/install", url))
+        .json(&install_request)
+        .send()
+        .await
+        .unwrap();
+
+    // Check the response status code, log the body.
+    // assert!(response.status().is_success());
+    let body = response.text().await.unwrap();
+    log::info!("/install response: {}", body);
+
+    // Make sure the "summary" plugin is installed
+    cln.rpc()
+        .call::<serde_json::Value, serde_json::Value>("summary", json!({}))
+        .unwrap();
 
     cln.stop().await.unwrap();
 }


### PR DESCRIPTION
This pull request adds two new endpoints:

-  `coffee_install`  
- `coffee_remove` 

To test the new endpoints: 
- 
-
```
curl -X 'POST' \
  'http://localhost:8080/install' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "plugin": "summary"
}' 
```
- 
```
curl -X 'POST' \
  'http://localhost:8080/remove' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "plugin": "summary"
}' 
```
