### PR TITLE
fix(lib): Fix pip braking change that required --break-system-packages

### DIFF
--- a/coffee_lib/src/plugin.rs
+++ b/coffee_lib/src/plugin.rs
@@ -52,7 +52,7 @@ impl PluginLang {
             PluginLang::PyPip => {
                 /* 1. RUN PIP install or poetry install
                  * 2. return the path of the main file */
-                let script = "pip3 install -r requirements.txt";
+                let script = "pip3 install -r requirements.txt --break-system-packages";
                 sh!(path, script, verbose);
                 let main_file = format!("{path}/{name}.py");
                 Ok(main_file)


### PR DESCRIPTION
Python decided after many years to tell the user that installing the dependencies with pip without a virtual environment is a bad idea

So now we should try a solution to handle these cases

```
➜  coffee git:(macros/sh-report-failure) ✗ coffee --network testnet install helpme
[2023-06-20T10:20:03Z ERROR coffee_lib::errors] ERROR #2: error: externally-managed-environment

    × This environment is externally managed
    ╰─> To install Python packages system-wide, try 'pacman -S
        python-xyz', where xyz is the package you are trying to
        install.

        If you wish to install a non-Arch-packaged Python package,
        create a virtual environment using 'python -m venv path/to/venv'.
        Then use path/to/venv/bin/python and path/to/venv/bin/pip.

        If you wish to install a non-Arch packaged Python application,
        it may be easiest to use 'pipx install xyz', which will manage a
        virtual environment for you. Make sure you have python-pipx
        installed via pacman.

    note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
    hint: See PEP 668 for the detailed specification.

```

The solution here is to pass the `--break-system-packages` to `pip install -r requirements.txt` but the question now if how we work also with an older version?

Fixes: https://github.com/coffee-tools/coffee/issues/148