### PR TITLE
fix(test): use the tmpdir in the correct way

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ dependencies = [
  "coffee_core",
  "log",
  "port-selector",
- "tempfile 3.6.0 (git+https://github.com/vincenzopalazzo/tempfile.git?branch=macros/clone-tmpdir)",
+ "tempfile",
  "tokio",
 ]
 
@@ -1176,12 +1176,6 @@ checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "ff"
@@ -1521,7 +1515,7 @@ dependencies = [
  "dyn-clone",
  "lazy_static",
  "newline-converter",
- "tempfile 3.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile",
  "termion 1.5.6",
  "thiserror",
  "unicode-segmentation",
@@ -2661,20 +2655,7 @@ checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
  "autocfg",
  "cfg-if",
- "fastrand 1.9.0",
- "redox_syscall 0.3.5",
- "rustix 0.37.22",
- "windows-sys",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.6.0"
-source = "git+https://github.com/vincenzopalazzo/tempfile.git?branch=macros/clone-tmpdir#b8582d9052e1af11ecfb2339d08d5874ef25f79b"
-dependencies = [
- "autocfg",
- "cfg-if",
- "fastrand 2.0.0",
+ "fastrand",
  "redox_syscall 0.3.5",
  "rustix 0.37.22",
  "windows-sys",

--- a/coffee_testing/Cargo.toml
+++ b/coffee_testing/Cargo.toml
@@ -10,7 +10,7 @@ log = "0.4.19"
 cln-test = { git = "https://github.com/laanwj/cln4rust.git", branch = "macros/test-framework" }
 cln-btc-test = { git = "https://github.com/laanwj/cln4rust.git", branch = "macros/test-framework" }
 coffee_core = { path = "../coffee_core" }
-tempfile = { git = "https://github.com/vincenzopalazzo/tempfile.git", branch = "macros/clone-tmpdir" }
+tempfile = "3.6.0"
 port-selector = "0.1.6"
 anyhow = "1.0.71"
 tokio = { version = "1.22.0", features = ["process", "time"] }

--- a/coffee_testing/src/lib.rs
+++ b/coffee_testing/src/lib.rs
@@ -9,6 +9,7 @@ pub mod prelude {
     pub use crate::macros::*;
     pub use tempfile;
 }
+use std::sync::Arc;
 
 use tempfile::TempDir;
 
@@ -72,7 +73,7 @@ impl coffee_core::CoffeeArgs for CoffeeTestingArgs {
 /// we need to perform integration testing for coffee.
 pub struct CoffeeTesting {
     inner: CoffeeManager,
-    root_path: TempDir,
+    root_path: Arc<TempDir>,
 }
 
 impl CoffeeTesting {
@@ -89,12 +90,15 @@ impl CoffeeTesting {
             .map_err(|err| anyhow::anyhow!("{err}"))?;
         Ok(Self {
             inner: coffee,
-            root_path: dir,
+            root_path: Arc::new(dir),
         })
     }
 
     // init coffee in a tmp directory with arguments.
-    pub async fn tmp_with_args(args: &CoffeeTestingArgs, tempdir: TempDir) -> anyhow::Result<Self> {
+    pub async fn tmp_with_args(
+        args: &CoffeeTestingArgs,
+        tempdir: Arc<TempDir>,
+    ) -> anyhow::Result<Self> {
         log::info!("Temporary directory: {:?}", tempdir);
 
         let coffee = CoffeeManager::new(args)
@@ -111,7 +115,7 @@ impl CoffeeTesting {
         &mut self.inner
     }
 
-    pub fn root_path(&self) -> TempDir {
+    pub fn root_path(&self) -> Arc<TempDir> {
         self.root_path.clone()
     }
 }

--- a/tests/src/coffee_integration_tests.rs
+++ b/tests/src/coffee_integration_tests.rs
@@ -1,4 +1,4 @@
-use std::sync::Once;
+use std::sync::{Arc, Once};
 
 use coffee_lib::plugin_manager::PluginManager;
 use coffee_testing::cln::Node;
@@ -36,7 +36,7 @@ pub async fn init_coffee_test() -> anyhow::Result<()> {
 pub async fn init_coffee_test_cmd() -> anyhow::Result<()> {
     init();
 
-    let dir = tempfile::tempdir()?;
+    let dir = Arc::new(tempfile::tempdir()?);
     let args = CoffeeTestingArgs {
         conf: None,
         data_dir: dir.path().clone().to_str().unwrap().to_owned(),
@@ -50,6 +50,8 @@ pub async fn init_coffee_test_cmd() -> anyhow::Result<()> {
         .await
         .unwrap();
 
+    // dropping the first coffee instance, but without delete the dir
+    drop(manager);
     let new_args = CoffeeTestingArgs {
         conf: None,
         data_dir: dir.path().clone().to_string_lossy().to_string(),


### PR DESCRIPTION
This commit revert my previous solution to clone the tmpdir, because it is wrong, the tmpdir wil be deleted when the first instance is dropped.

So this commit use the Arc to pass around the tmp dir, so in this way we keep a smart pointer and we solve all our problem.