### PR TITLE
fix(test): increase the timeout for the plugin integration testing

### DIFF
--- a/tests/src/coffee_plugin_integration_tests.rs
+++ b/tests/src/coffee_plugin_integration_tests.rs
@@ -4,7 +4,7 @@ use coffee_testing::cln::Node;
 use crate::init;
 
 #[tokio::test]
-#[ntest::timeout(120000)]
+#[ntest::timeout(560000)]
 pub async fn init_cln_with_coffee_plugin_test() {
     init();
 
@@ -29,7 +29,7 @@ pub async fn init_cln_with_coffee_plugin_test() {
 }
 
 #[tokio::test]
-#[ntest::timeout(120000)]
+#[ntest::timeout(560000)]
 pub async fn init_cln_with_coffee_add_remore_test() {
     init();
 


### PR DESCRIPTION
This commit just increate the timeout for plugin integration testing.