### PR TITLE
fix(test): run core lightning with the plugin directly

### DIFF
--- a/coffee_testing/src/cln.rs
+++ b/coffee_testing/src/cln.rs
@@ -73,6 +73,10 @@ impl Drop for Node {
 
 impl Node {
     pub async fn tmp() -> anyhow::Result<Self> {
+        Self::with_params("").await
+    }
+
+    pub async fn with_params(params: &str) -> anyhow::Result<Self> {
         let btc = BtcNode::tmp().await?;
 
         let dir = tempfile::tempdir()?;
@@ -80,10 +84,11 @@ impl Node {
         let process = macros::lightningd!(
             dir,
             port::random_free_port().unwrap(),
-            "--network=regtest --log-level=debug --bitcoin-rpcuser={} --bitcoin-rpcpassword={} --bitcoin-rpcport={}",
+            "--network=regtest --log-level=debug --bitcoin-rpcuser={} --bitcoin-rpcpassword={} --bitcoin-rpcport={} {}",
             btc.user,
             btc.pass,
             btc.port,
+            params,
         )?;
 
         let rpc = LightningRPC::new(dir.path().join(".lightning/regtest").join("lightning-rpc"));

--- a/tests/src/coffee_plugin_integration_tests.rs
+++ b/tests/src/coffee_plugin_integration_tests.rs
@@ -8,23 +8,13 @@ use crate::init;
 pub async fn init_cln_with_coffee_plugin_test() {
     init();
 
-    let mut cln = Node::tmp().await.unwrap();
-
     let cargo_target = concat!(env!("CARGO_MANIFEST_DIR"), "/..");
     let path = std::path::Path::new(cargo_target).to_str().unwrap();
     let plugin_path = format!("{path}/target/debug/coffee_plugin");
     log::info!("plugin path {plugin_path}");
-    let result: serde_json::Value = cln
-        .rpc()
-        .call(
-            "plugin",
-            serde_json::json!({
-                "subcommand": "start",
-                "plugin": plugin_path,
-            }),
-        )
+    let mut cln = Node::with_params(&format!("--plugin={plugin_path}"))
+        .await
         .unwrap();
-    log::info!("cln response {result}");
     cln.stop().await.unwrap();
 }
 
@@ -33,22 +23,13 @@ pub async fn init_cln_with_coffee_plugin_test() {
 pub async fn init_cln_with_coffee_add_remore_test() {
     init();
 
-    let mut cln = Node::tmp().await.unwrap();
-
     let cargo_target = concat!(env!("CARGO_MANIFEST_DIR"), "/..");
     let path = std::path::Path::new(cargo_target).to_str().unwrap();
     let plugin_path = format!("{path}/target/debug/coffee_plugin");
     log::info!("plugin path {plugin_path}");
 
-    let _: serde_json::Value = cln
-        .rpc()
-        .call(
-            "plugin",
-            serde_json::json!({
-                "subcommand": "start",
-                "plugin": plugin_path,
-            }),
-        )
+    let mut cln = Node::with_params(&format!("--plugin={plugin_path}"))
+        .await
         .unwrap();
 
     let result: serde_json::Value = cln
@@ -71,22 +52,13 @@ pub async fn init_cln_with_coffee_add_remore_test() {
 pub async fn init_cln_with_coffee_install_plugin_test() {
     init();
 
-    let mut cln = Node::tmp().await.unwrap();
-
     let cargo_target = concat!(env!("CARGO_MANIFEST_DIR"), "/..");
     let path = std::path::Path::new(cargo_target).to_str().unwrap();
     let plugin_path = format!("{path}/target/debug/coffee_plugin");
     log::info!("plugin path {plugin_path}");
 
-    let _: serde_json::Value = cln
-        .rpc()
-        .call(
-            "plugin",
-            serde_json::json!({
-                "subcommand": "start",
-                "plugin": plugin_path,
-            }),
-        )
+    let mut cln = Node::with_params(&format!("--plugin={plugin_path}"))
+        .await
         .unwrap();
 
     let result: serde_json::Value = cln


### PR DESCRIPTION
Inside the CI we noted that the tests over the plugin get stuck and my suspection is that we had some problem to run the plugin with the `lightning-cli plugin start`.

So this is removing the method to start it when cln will start, and running it with the deamon itself.