### PR TITLE
Deprecate the nurse command and add a test

### DIFF
--- a/coffee_cmd/src/main.rs
+++ b/coffee_cmd/src/main.rs
@@ -7,7 +7,7 @@ use radicle_term as term;
 use coffee_core::coffee::CoffeeManager;
 use coffee_lib::errors::CoffeeError;
 use coffee_lib::plugin_manager::PluginManager;
-use coffee_lib::types::response::{NurseStatus, UpgradeStatus};
+use coffee_lib::types::response::UpgradeStatus;
 
 use crate::cmd::CoffeeArgs;
 use crate::cmd::CoffeeCommand;
@@ -116,19 +116,7 @@ async fn main() -> Result<(), CoffeeError> {
             Err(err) => Err(err),
         },
         CoffeeCommand::Nurse {} => {
-            let mut spinner =
-                term::spinner("Trying restoring from a corrupted status!".to_string());
-            match coffee.nurse().await {
-                Ok(val) => {
-                    match val.status {
-                        NurseStatus::Corrupted => spinner.message("Storage refreshed"),
-                        NurseStatus::Sane => spinner
-                            .message("Storage files are not corrupt. No need to run coffee nurse"),
-                    }
-                    spinner.finish();
-                }
-                Err(err) => spinner.error(format!("Error while refreshing storage: {err}")),
-            };
+            term::info!("Nurse command is not implemented");
             Ok(())
         }
     };

--- a/coffee_lib/src/plugin_manager.rs
+++ b/coffee_lib/src/plugin_manager.rs
@@ -27,9 +27,6 @@ pub trait PluginManager {
     /// upgrade a single or multiple repositories.
     async fn upgrade(&mut self, repo: &str) -> Result<CoffeeUpgrade, CoffeeError>;
 
-    /// refresh the storage information about the remote repositories of the plugin manager.
-    async fn remote_sync(&mut self) -> Result<(), CoffeeError>;
-
     /// add the remote repository to the plugin manager.
     async fn add_remote(&mut self, name: &str, url: &str) -> Result<(), CoffeeError>;
 
@@ -47,5 +44,5 @@ pub trait PluginManager {
     async fn show(&mut self, plugin: &str) -> Result<CoffeeShow, CoffeeError>;
 
     /// clean up storage information about the remote repositories of the plugin manager.
-    async fn nurse(&mut self) -> Result<CoffeeNurse, CoffeeError>;
+    async fn nurse(&mut self) -> Result<(), CoffeeError>;
 }

--- a/coffee_lib/src/types/mod.rs
+++ b/coffee_lib/src/types/mod.rs
@@ -57,17 +57,6 @@ pub mod response {
     }
 
     #[derive(Debug, Serialize, Deserialize)]
-    pub enum NurseStatus {
-        Corrupted,
-        Sane,
-    }
-
-    #[derive(Debug, Serialize, Deserialize)]
-    pub struct CoffeeNurse {
-        pub status: NurseStatus,
-    }
-
-    #[derive(Debug, Serialize, Deserialize)]
     pub enum UpgradeStatus {
         UpToDate,
         Updated,

--- a/coffee_testing/src/btc.rs
+++ b/coffee_testing/src/btc.rs
@@ -66,7 +66,7 @@ impl Drop for BtcNode {
 }
 
 impl BtcNode {
-    pub async fn tmp() -> anyhow::Result<Self> {
+    pub async fn tmp(network: &str) -> anyhow::Result<Self> {
         let dir = tempfile::tempdir()?;
         let user = "crab".to_owned();
         let pass = "crab".to_owned();
@@ -74,7 +74,7 @@ impl BtcNode {
         let process = macros::bitcoind!(
             dir,
             port,
-            "-server -regtest -rpcuser={user} -rpcpassword={pass}"
+            "-server -{network} -rpcuser={user} -rpcpassword={pass}"
         )?;
         let rpc = Client::new(
             &format!("http://localhost:{port}"),

--- a/docs/docs-book/src/using-coffee.md
+++ b/docs/docs-book/src/using-coffee.md
@@ -130,14 +130,6 @@ coffee list
 ```bash
 coffee show <plugin_name>
 ```
-
-### To fix corrupt remote repositories local clones
-
-> ✅ Implemented
-
-```bash
-coffee nurse
-```
 _________
 ## Running coffee as a server
 

--- a/tests/src/coffee_httpd_integration_tests.rs
+++ b/tests/src/coffee_httpd_integration_tests.rs
@@ -11,7 +11,7 @@ use crate::init;
 pub async fn httpd_init_add_remote() {
     init();
 
-    let mut cln = Node::tmp().await.unwrap();
+    let mut cln = Node::tmp("regtest").await.unwrap();
     let lightning_dir = cln.rpc().getinfo().unwrap().ligthning_dir;
     let lightning_dir = lightning_dir.strip_suffix("/regtest").unwrap();
     let manager = CoffeeHTTPDTesting::tmp(lightning_dir.to_string())

--- a/tests/src/coffee_plugin_integration_tests.rs
+++ b/tests/src/coffee_plugin_integration_tests.rs
@@ -12,7 +12,7 @@ pub async fn init_cln_with_coffee_plugin_test() {
     let path = std::path::Path::new(cargo_target).to_str().unwrap();
     let plugin_path = format!("{path}/target/debug/coffee_plugin");
     log::info!("plugin path {plugin_path}");
-    let mut cln = Node::with_params(&format!("--plugin={plugin_path}"))
+    let mut cln = Node::with_params(&format!("--plugin={plugin_path}"), "regtest")
         .await
         .unwrap();
     cln.stop().await.unwrap();
@@ -28,7 +28,7 @@ pub async fn init_cln_with_coffee_add_remore_test() {
     let plugin_path = format!("{path}/target/debug/coffee_plugin");
     log::info!("plugin path {plugin_path}");
 
-    let mut cln = Node::with_params(&format!("--plugin={plugin_path}"))
+    let mut cln = Node::with_params(&format!("--plugin={plugin_path}"), "regtest")
         .await
         .unwrap();
 
@@ -57,7 +57,7 @@ pub async fn init_cln_with_coffee_install_plugin_test() {
     let plugin_path = format!("{path}/target/debug/coffee_plugin");
     log::info!("plugin path {plugin_path}");
 
-    let mut cln = Node::with_params(&format!("--plugin={plugin_path}"))
+    let mut cln = Node::with_params(&format!("--plugin={plugin_path}"), "regtest")
         .await
         .unwrap();
 


### PR DESCRIPTION
e51181172ba221ed944917b1d0eb57aac82022fd modifies the current test framework to allow to run a lightning node in any network specified in the test itself. 
-  previously we could only run lightning in `regtest`

49548f0c247b19491aa56fcf41eba826bc14922f adds a new test to mimic the issue where coffee fails to install the same plugin in 2 different networks.

Related issue: #172 