### PR TITLE
fix(core): store the repository globally

### DIFF
--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -27,14 +27,14 @@ use super::config;
 use crate::config::CoffeeConf;
 use crate::CoffeeArgs;
 
-pub type PluginName = String;
+pub type RepoName = String;
 
 #[derive(Serialize, Deserialize)]
 /// FIXME: move the list of plugin
 /// and the list of repository inside this struct.
 pub struct CoffeeStorageInfo {
     pub config: config::CoffeeConf,
-    pub repositories: HashMap<PluginName, RepositoryInfo>,
+    pub repositories: HashMap<RepoName, RepositoryInfo>,
 }
 
 impl From<&CoffeeManager> for CoffeeStorageInfo {
@@ -59,6 +59,7 @@ impl From<&CoffeeManager> for CoffeeStorageInfo {
 
 pub struct CoffeeManager {
     config: config::CoffeeConf,
+    #[serde(skip_serializing, skip_deerializing)]
     repos: HashMap<String, Box<dyn Repository + Send + Sync>>,
     /// Core lightning configuration managed by coffee
     coffee_cln_config: CLNConf,
@@ -97,6 +98,7 @@ impl CoffeeManager {
         // this is really needed? I think no, because coffee at this point
         // have a new conf loading
         self.config = store.config;
+        let repositories = self.storage.load::<>("repository")?;
         store
             .repositories
             .iter()

--- a/coffee_github/src/repository.rs
+++ b/coffee_github/src/repository.rs
@@ -164,7 +164,9 @@ impl Github {
                     }
 
                     let Some(exec_path) = exec_path else {
-                        return Err(error!("exec path not known, but we should know at this point."));
+                        return Err(error!(
+                            "exec path not known, but we should know at this point."
+                        ));
                     };
 
                     debug!("exec path is {exec_path}");

--- a/coffee_lib/src/url.rs
+++ b/coffee_lib/src/url.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 /// This struct will make sure our URLs are of the
 /// correct format and will also check correctness
 /// of associated fields
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct URL {
     /// the url name in case of remote
     pub name: String,

--- a/coffee_storage/src/file.rs
+++ b/coffee_storage/src/file.rs
@@ -34,10 +34,10 @@ impl FileStorage {
 }
 
 #[async_trait]
-impl<T> StorageManager<T> for FileStorage {
+impl StorageManager for FileStorage {
     type Err = CoffeeError;
 
-    async fn load<'c>(&self, _: &str) -> Result<T, Self::Err>
+    async fn load<T>(&self, _: &str) -> Result<T, Self::Err>
     where
         T: DeserializeOwned + Send + Sync,
     {
@@ -50,7 +50,7 @@ impl<T> StorageManager<T> for FileStorage {
         Ok(val)
     }
 
-    async fn store(&self, _: &str, to_store: &T) -> Result<(), Self::Err>
+    async fn store<T>(&self, _: &str, to_store: &T) -> Result<(), Self::Err>
     where
         T: Serialize + Send + Sync,
     {

--- a/coffee_storage/src/model/repository.rs
+++ b/coffee_storage/src/model/repository.rs
@@ -3,12 +3,12 @@
 use coffee_lib::{plugin::Plugin, url::URL};
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum Kind {
     Git,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Repository {
     pub kind: Kind,
     pub name: String,

--- a/coffee_storage/src/nosql_db.rs
+++ b/coffee_storage/src/nosql_db.rs
@@ -23,10 +23,10 @@ impl NoSQlStorage {
 }
 
 #[async_trait]
-impl<T> StorageManager<T> for NoSQlStorage {
+impl StorageManager for NoSQlStorage {
     type Err = CoffeeError;
 
-    async fn load<'c>(&self, key: &str) -> Result<T, Self::Err>
+    async fn load<T>(&self, key: &str) -> Result<T, Self::Err>
     where
         T: serde::de::DeserializeOwned + Send + Sync,
     {
@@ -40,7 +40,7 @@ impl<T> StorageManager<T> for NoSQlStorage {
         Ok(value)
     }
 
-    async fn store(&self, key: &str, to_store: &T) -> Result<(), Self::Err>
+    async fn store<T>(&self, key: &str, to_store: &T) -> Result<(), Self::Err>
     where
         T: serde::Serialize + Send + Sync,
     {

--- a/coffee_storage/src/storage.rs
+++ b/coffee_storage/src/storage.rs
@@ -6,18 +6,18 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 
 #[async_trait]
-pub trait StorageManager<T> {
+pub trait StorageManager {
     type Err;
 
     /// async call to persist the information
     /// on disk.
-    async fn store(&self, key: &str, to_store: &T) -> Result<(), Self::Err>
+    async fn store<T>(&self, key: &str, to_store: &T) -> Result<(), Self::Err>
     where
         T: Serialize + Send + Sync;
 
     /// async call to load the data that was made persistent
     /// from the previous `store` call.
-    async fn load<'c>(&self, key: &str) -> Result<T, Self::Err>
+    async fn load<T>(&self, key: &str) -> Result<T, Self::Err>
     where
         T: DeserializeOwned + Send + Sync;
 }

--- a/coffee_testing/src/btc.rs
+++ b/coffee_testing/src/btc.rs
@@ -50,13 +50,14 @@ impl Drop for BtcNode {
     fn drop(&mut self) {
         for process in self.process.iter() {
             let Some(child) = process.id() else {
-               continue;
+                continue;
             };
             let Ok(mut kill) = std::process::Command::new("kill")
                 .args(["-s", "SIGKILL", &child.to_string()])
-                .spawn() else {
-                    continue;
-                };
+                .spawn()
+            else {
+                continue;
+            };
             let _ = kill.wait();
         }
 

--- a/coffee_testing/src/cln.rs
+++ b/coffee_testing/src/cln.rs
@@ -56,13 +56,14 @@ impl Drop for Node {
     fn drop(&mut self) {
         for process in self.process.iter() {
             let Some(child) = process.id() else {
-               continue;
+                continue;
             };
             let Ok(mut kill) = std::process::Command::new("kill")
                 .args(["-s", "SIGKILL", &child.to_string()])
-                .spawn() else {
-                    continue;
-                };
+                .spawn()
+            else {
+                continue;
+            };
             let _ = kill.wait();
         }
 

--- a/coffee_testing/src/lib.rs
+++ b/coffee_testing/src/lib.rs
@@ -160,13 +160,14 @@ pub struct CoffeeHTTPDTesting {
 impl Drop for CoffeeHTTPDTesting {
     fn drop(&mut self) {
         let Some(child) = self.httpd_pid.id() else {
-               return;
-            };
+            return;
+        };
         let Ok(mut kill) = std::process::Command::new("kill")
-                .args(["-s", "SIGKILL", &child.to_string()])
-                .spawn() else {
-                    return;
-                };
+            .args(["-s", "SIGKILL", &child.to_string()])
+            .spawn()
+        else {
+            return;
+        };
         let _ = kill.wait();
     }
 }


### PR DESCRIPTION
While working with coffee, we noted that there was a
limitation on how we store the repositories.

In fact, we store them once per network, and this causes problem
when we try to work with multiple networks,
and installing the same plugins.

Now with this commit, we store the repositories globally,
outside of the configuration network, so in this way we
can download once the remote is on and use
it in multiple directories.

Fixes https://github.com/coffee-tools/coffee/issues/172
