### PR TITLE
supress intended clippy warnings 

### DIFF
--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -90,18 +90,19 @@ impl CoffeeManager {
     /// when coffee is configured, run an inventory to collect all the necessary information
     /// about the coffee ecosystem.
     async fn inventory(&mut self) -> Result<(), CoffeeError> {
-        self.storage
+        let _ = self
+            .storage
             .load::<CoffeeStorageInfo>(&self.config.network)
             .await
-            .and_then(|store| {
+            .map(|store| {
                 self.config = store.config;
-                Ok(())
             });
         // FIXME: check if this exist in a better wai
-        self.storage
+        let _ = self
+            .storage
             .load::<HashMap<RepoName, RepositoryInfo>>("repositories")
             .await
-            .and_then(|item| {
+            .map(|item| {
                 log::debug!("repositories in store {:?}", item);
                 item.iter().for_each(|repo| match repo.1.kind {
                     Kind::Git => {
@@ -109,7 +110,6 @@ impl CoffeeManager {
                         self.repos.insert(repo.name(), Box::new(repo));
                     }
                 });
-                Ok(())
             });
 
         if let Err(err) = self.coffee_cln_config.parse() {

--- a/tests/src/coffee_integration_tests.rs
+++ b/tests/src/coffee_integration_tests.rs
@@ -306,7 +306,6 @@ pub async fn install_plugin_in_two_networks() -> anyhow::Result<()> {
         network: "regtest".to_string(),
     };
     let mut manager = CoffeeTesting::tmp_with_args(&args, dir.clone()).await?;
-    let root_path = manager.root_path().to_owned();
     let result = manager.coffee().setup(&lightning_regtest_dir).await;
     assert!(result.is_ok(), "{:?}", result);
     // Add lightningd remote repository


### PR DESCRIPTION
- handles the `Err` variant in 2 statements in coffee.rs
- suppresses 2 clippy warnings that are intended 
- removes redundant `root_path` from `install_plugin_in_two_networks` test