### PR TITLE
fix(lib): fixing the feature confitional compilation

### DIFF
--- a/coffee_lib/src/types/mod.rs
+++ b/coffee_lib/src/types/mod.rs
@@ -2,31 +2,68 @@
 
 // Definition of the request types.
 pub mod request {
+    #[cfg(feature = "open-api")]
     use paperclip::actix::Apiv2Schema;
     use serde::{Deserialize, Serialize};
 
+    #[cfg(not(feature = "open-api"))]
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct Install {
+        pub plugin: String,
+        pub try_dynamic: bool,
+    }
+
+    #[cfg(not(feature = "open-api"))]
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct Remove {
+        pub plugin: String,
+    }
+
+    #[cfg(not(feature = "open-api"))]
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct RemoteAdd {
+        pub repository_name: String,
+        pub repository_url: String,
+    }
+
+    #[cfg(not(feature = "open-api"))]
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct RemoteRm {
+        pub repository_name: String,
+    }
+
+    #[cfg(not(feature = "open-api"))]
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct Show {
+        pub plugin: String,
+    }
+    #[cfg(feature = "open-api")]
     #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
     pub struct Install {
         pub plugin: String,
         pub try_dynamic: bool,
     }
 
+    #[cfg(feature = "open-api")]
     #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
     pub struct Remove {
         pub plugin: String,
     }
 
+    #[cfg(feature = "open-api")]
     #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
     pub struct RemoteAdd {
         pub repository_name: String,
         pub repository_url: String,
     }
 
+    #[cfg(feature = "open-api")]
     #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
     pub struct RemoteRm {
         pub repository_name: String,
     }
 
+    #[cfg(feature = "open-api")]
     #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
     pub struct Show {
         pub plugin: String,


### PR DESCRIPTION
If you are installing coffee with make install you will receive the following error

```
   Compiling git2 v0.16.1
   Compiling coffee_lib v0.1.0 (/home/vincent/Github/coffee/coffee/coffee_lib)
error[E0433]: failed to resolve: use of undeclared crate or module `paperclip`
 --> coffee_lib/src/types/mod.rs:5:9
  |
5 |     use paperclip::actix::Apiv2Schema;
  |         ^^^^^^^^^ use of undeclared crate or module `paperclip`

error: cannot determine resolution for the derive macro `Apiv2Schema`
 --> coffee_lib/src/types/mod.rs:8:34
  |
8 |     #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
  |                                  ^^^^^^^^^^^
  |
  = note: import resolution is stuck, try simplifying macro imports

error: cannot determine resolution for the derive macro `Apiv2Schema`
  --> coffee_lib/src/types/mod.rs:14:34
   |
14 |     #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
   |                                  ^^^^^^^^^^^
   |
   = note: import resolution is stuck, try simplifying macro imports

error: cannot determine resolution for the derive macro `Apiv2Schema`
  --> coffee_lib/src/types/mod.rs:19:34
   |
19 |     #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
   |                                  ^^^^^^^^^^^
   |
   = note: import resolution is stuck, try simplifying macro imports

error: cannot determine resolution for the derive macro `Apiv2Schema`
  --> coffee_lib/src/types/mod.rs:25:34
   |
25 |     #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
   |                                  ^^^^^^^^^^^
   |
   = note: import resolution is stuck, try simplifying macro imports

error: cannot determine resolution for the derive macro `Apiv2Schema`
  --> coffee_lib/src/types/mod.rs:30:34
   |
30 |     #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
   |                                  ^^^^^^^^^^^
   |
   = note: import resolution is stuck, try simplifying macro imports

For more information about this error, try `rustc --explain E0433`.
error: could not compile `coffee_lib` (lib) due to 6 previous errors
warning: build failed, waiting for other jobs to finish...
error: failed to compile `coffee v0.0.1-alpha.1 (/home/vincent/Github/coffee/coffee/coffee_cmd)`, intermediate artifacts can be found at `/home/vincent/Github/coffee/coffee/target`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

```

This commit fix the confitional compilation

Fixes: 57b218de
Link https://github.com/coffee-tools/coffee/pull/157

cc @tareknaser360 