### PR TITLE
feat(cmd): print the short version of git HEAD

### DIFF
--- a/coffee_cmd/src/coffee_term/command_show.rs
+++ b/coffee_cmd/src/coffee_term/command_show.rs
@@ -60,14 +60,9 @@ pub fn show_remote_list(remote_list: Result<CoffeeRemote, CoffeeError>) -> Resul
     table.divider();
 
     for repository in &repositories {
-        let commit_id = match &repository.commit_id {
-            Some(commit_id) => commit_id.to_owned(),
-            None => String::from(""),
-        };
-        let date = match &repository.date {
-            Some(date) => date.to_owned(),
-            None => String::from(""),
-        };
+        let mut commit_id = repository.commit_id.clone().unwrap_or_default();
+        commit_id = commit_id.chars().take(7).collect::<String>();
+        let date = repository.date.clone().unwrap_or_default();
         table.push([
             term::format::positive("●").into(),
             term::format::highlight(repository.local_name.to_owned()),

--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -6,6 +6,7 @@ use std::vec::Vec;
 use tokio::fs;
 
 use async_trait::async_trait;
+use chrono::{TimeZone, Utc};
 use clightningrpc_common::client::Client;
 use clightningrpc_common::json_utils;
 use clightningrpc_conf::{CLNConf, SyncCLNConf};
@@ -14,7 +15,6 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 
-use chrono::{TimeZone, Utc};
 use coffee_github::repository::Github;
 use coffee_lib::errors::CoffeeError;
 use coffee_lib::plugin_manager::PluginManager;


### PR DESCRIPTION
prints the first 7 characters of the commit HEAD instead of the entire commit hash
fixes #192 