### PR TITLE
fix(lib): simplify and improve sh! macro

### DIFF
--- a/coffee_lib/src/macros.rs
+++ b/coffee_lib/src/macros.rs
@@ -15,31 +15,27 @@ macro_rules! error {
 macro_rules! sh {
     ($root: expr, $script:expr, $verbose:expr) => {{
         let script = $script.trim();
-        let cmds = script.split("\n"); // Check if the script contains `\`
-        log::debug!("cmds: {:?}", cmds);
-        for cmd in cmds {
-            log::debug!("cmd {:?}", cmd);
-            let cmd_tok: Vec<&str> = cmd.split(" ").collect();
-            let command = cmd_tok.first().unwrap().to_string();
-            let mut cmd = Command::new(command);
-            cmd.args(&cmd_tok[1..cmd_tok.len()]);
-            cmd.current_dir($root);
-            let command = if $verbose {
-                cmd.spawn()
-                    .expect("Unable to run the command")
-                    .wait_with_output()
-                    .await?
-            } else {
-                cmd.output().await?
-            };
+        log::debug!("script: {:?}", script);
 
-            if !command.status.success() {
-                let mut content = String::from_utf8(command.stderr).unwrap();
-                if content.trim().is_empty() {
-                    content = String::from_utf8(command.stdout).unwrap();
-                }
-                return Err(CoffeeError::new(2, &content));
+        let mut cmd = Command::new("sh");
+        cmd.args(&["-c", &script]);
+        cmd.current_dir($root);
+
+        let command = if $verbose {
+            cmd.spawn()
+                .map_err(|_| error!("Unable to run the command"))?
+                .wait_with_output()
+                .await?
+        } else {
+            cmd.output().await?
+        };
+
+        if !command.status.success() {
+            let mut content = String::from_utf8(command.stderr).unwrap();
+            if content.trim().is_empty() {
+                content = String::from_utf8(command.stdout).unwrap();
             }
+            return Err(CoffeeError::new(2, &content));
         }
     }};
 


### PR DESCRIPTION
working on https://github.com/coffee-tools/coffee/issues/194 I noticed a issue with the `sh` macro when trying to execute a script that uses a pipe. Looking into the implementation I saw that it tries to manually parse out the commands, which is pretty error prone. so, instead of trying to manually parse the script and potentially making errors, let the actual `sh` command do the work correctly