### PR TITLE
ci: update to the last cln version on master

### DIFF
--- a/coffee_testing/src/cln.rs
+++ b/coffee_testing/src/cln.rs
@@ -33,6 +33,7 @@ pub mod macros {
                     .arg(format!("--lightning-dir={path}"))
                     .arg("--dev-fast-gossip")
                     .arg("--funding-confirms=1")
+                    .arg("--developer")
                     .stdout(Stdio::null())
                     .spawn()
             }.await

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ ENV CLIGHTNING_VERSION=master
 RUN git clone https://github.com/ElementsProject/lightning.git --branch=$CLIGHTNING_VERSION && \
     cd lightning && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
-    ./configure --enable-developer --disable-rust && git submodule update --init --recursive && \
+    ./configure --disable-rust && git submodule update --init --recursive && \
     pip3 install --upgrade pip && \
     pip3 install mako mistune==0.8.4 mrkd && \
     make -j$(nproc) && make install


### PR DESCRIPTION
This is being added instead of the build-time setting for v23.11.