### PR TITLE
Add Command to List Plugins in a Remote Repository

### DIFF
--- a/coffee_cmd/src/main.rs
+++ b/coffee_cmd/src/main.rs
@@ -5,9 +5,10 @@ use clap::Parser;
 use radicle_term as term;
 
 use coffee_core::coffee::CoffeeManager;
+use coffee_lib::error;
 use coffee_lib::errors::CoffeeError;
 use coffee_lib::plugin_manager::PluginManager;
-use coffee_lib::types::response::UpgradeStatus;
+use coffee_lib::types::response::{CoffeeRemote, UpgradeStatus};
 
 use crate::cmd::CoffeeArgs;
 use crate::cmd::CoffeeCommand;
@@ -73,34 +74,70 @@ async fn main() -> Result<(), CoffeeError> {
             }
             Ok(())
         }
-        CoffeeCommand::Remote { action } => match action {
-            RemoteAction::Add { name, url } => {
-                let mut spinner = term::spinner(format!("Fetch remote from {url}"));
-                let result = coffee.add_remote(&name, &url).await;
-                if let Err(err) = &result {
-                    spinner.error(format!("Error while add remote: {err}"));
-                    return result;
+        CoffeeCommand::Remote {
+            action,
+            plugins,
+            name,
+        } => {
+            if plugins {
+                let result = coffee.get_plugins_in_remote(&name.unwrap()).await;
+                coffee_term::show_list(result)
+            } else {
+                match action {
+                    Some(RemoteAction::Add { name, url }) => {
+                        let mut spinner = term::spinner(format!("Fetch remote from {url}"));
+                        let result = coffee.add_remote(&name, &url).await;
+                        if let Err(err) = &result {
+                            spinner.error(format!("Error while add remote: {err}"));
+                            return result;
+                        }
+                        spinner.message("Remote added!");
+                        spinner.finish();
+                        Ok(())
+                    }
+                    Some(RemoteAction::Rm { name }) => {
+                        let mut spinner = term::spinner(format!("Removing remote {name}"));
+                        let result = coffee.rm_remote(&name).await;
+                        if let Err(err) = &result {
+                            spinner.error(format!("Error while removing the repository: {err}"));
+                            return result;
+                        }
+                        spinner.message("Remote removed!");
+                        spinner.finish();
+                        Ok(())
+                    }
+                    Some(RemoteAction::List {}) => {
+                        let remotes = coffee.list_remotes().await;
+                        coffee_term::show_remote_list(remotes)
+                    }
+                    None => {
+                        // This is the case when the user does not provides the
+                        // plugins flag, so we just show the remote repository
+                        // information
+
+                        // The name will be always Some because of the
+                        // arg_required_else_help = true in the clap
+                        // attribute
+                        let name =
+                            name.ok_or_else(|| error!("No remote repository name provided"))?;
+                        let remotes = coffee.list_remotes().await?;
+                        let remotes = remotes
+                            .remotes
+                            .ok_or_else(|| error!("Couldn't get the remote repositories"))?;
+                        let remote = remotes
+                            .iter()
+                            .find(|remote| remote.local_name == name)
+                            .ok_or_else(|| error!("Couldn't find the remote repository"))?;
+                        // A workaround to show the remote repository information
+                        // in the same way as the list command
+                        let remote = Ok(CoffeeRemote {
+                            remotes: Some(vec![remote.clone()]),
+                        });
+                        coffee_term::show_remote_list(remote)
+                    }
                 }
-                spinner.message("Remote added!");
-                spinner.finish();
-                Ok(())
             }
-            RemoteAction::Rm { name } => {
-                let mut spinner = term::spinner(format!("Removing remote {name}"));
-                let result = coffee.rm_remote(&name).await;
-                if let Err(err) = &result {
-                    spinner.error(format!("Error while removing the repository: {err}"));
-                    return result;
-                }
-                spinner.message("Remote removed!");
-                spinner.finish();
-                Ok(())
-            }
-            RemoteAction::List {} => {
-                let remotes = coffee.list_remotes().await;
-                coffee_term::show_remote_list(remotes)
-            }
-        },
+        }
         CoffeeCommand::Setup { cln_conf } => {
             // FIXME: read the core lightning config
             // and the coffee script

--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -414,6 +414,16 @@ impl PluginManager for CoffeeManager {
         })
     }
 
+    async fn get_plugins_in_remote(&self, name: &str) -> Result<CoffeeList, CoffeeError> {
+        log::debug!("Listing plugins for repository: {}", name);
+        let repo = self
+            .repos
+            .get(name)
+            .ok_or_else(|| error!("repository with name: {name} not found"))?;
+        let plugins = repo.list().await?;
+        Ok(CoffeeList { plugins })
+    }
+
     async fn show(&mut self, plugin: &str) -> Result<CoffeeShow, CoffeeError> {
         for repo in self.repos.values() {
             if let Some(plugin) = repo.get_plugin_by_name(plugin) {

--- a/coffee_core/src/lib.rs
+++ b/coffee_core/src/lib.rs
@@ -15,7 +15,7 @@ pub enum CoffeeOperation {
     Upgrade(String),
     Remove(String),
     /// Remote(name repository, url of the repository)
-    Remote(RemoteAction),
+    Remote(Option<RemoteAction>, bool, Option<String>),
     /// Setup(core lightning root path)
     Setup(String),
     Show(String),

--- a/coffee_httpd/src/httpd/server.rs
+++ b/coffee_httpd/src/httpd/server.rs
@@ -61,6 +61,7 @@ pub async fn run_httpd<T: ToSocketAddrs>(
             .service(coffee_remote_list)
             .service(coffee_show)
             .service(coffee_search)
+            .service(coffee_list_plugins_in_remote)
             .with_json_spec_at("/api/v1")
             .build()
     })
@@ -154,6 +155,20 @@ async fn coffee_remote_rm(
 async fn coffee_remote_list(data: web::Data<AppState>) -> Result<Json<Value>, Error> {
     let mut coffee = data.coffee.lock().await;
     let result = coffee.list_remotes().await;
+
+    handle_httpd_response!(result)
+}
+
+#[api_v2_operation]
+#[get("/remote/list_plugins")]
+async fn coffee_list_plugins_in_remote(
+    data: web::Data<AppState>,
+    body: Json<RemotePluginsList>,
+) -> Result<Json<Value>, Error> {
+    let repository_name = &body.repository_name;
+
+    let coffee = data.coffee.lock().await;
+    let result = coffee.get_plugins_in_remote(repository_name).await;
 
     handle_httpd_response!(result)
 }

--- a/coffee_lib/src/plugin_manager.rs
+++ b/coffee_lib/src/plugin_manager.rs
@@ -36,6 +36,9 @@ pub trait PluginManager {
     /// list the remote repositories for the plugin manager.
     async fn list_remotes(&mut self) -> Result<CoffeeRemote, CoffeeError>;
 
+    /// List the plugins available in a remote repository.
+    async fn get_plugins_in_remote(&self, name: &str) -> Result<CoffeeList, CoffeeError>;
+
     /// set up the core lightning configuration target for the
     /// plugin manager.
     async fn setup(&mut self, cln_conf_path: &str) -> Result<(), CoffeeError>;

--- a/coffee_lib/src/types/mod.rs
+++ b/coffee_lib/src/types/mod.rs
@@ -72,6 +72,12 @@ pub mod request {
 
     #[cfg(feature = "open-api")]
     #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
+    pub struct RemotePluginsList {
+        pub repository_name: String,
+    }
+
+    #[cfg(feature = "open-api")]
+    #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
     pub struct Show {
         pub plugin: String,
     }
@@ -96,6 +102,10 @@ pub mod response {
         pub plugin: Plugin,
     }
 
+    // This struct is used to represent the list of plugins
+    // that are installed in the coffee configuration
+    // or the list of plugins that are available in a remote
+    // repository.
     #[derive(Debug, Serialize, Deserialize)]
     pub struct CoffeeList {
         pub plugins: Vec<Plugin>,

--- a/docs/docs-book/src/using-coffee.md
+++ b/docs/docs-book/src/using-coffee.md
@@ -68,6 +68,14 @@ To list plugin repositories, simply run the following command.
 coffee remote list 
 ```
 
+To list available plugins in a specific remote repository
+
+> ✅ Implemented
+
+```bash
+coffee remote <repository_name> --plugins
+```
+
 ### Install a Plugin
 
 > ✅ Implemented


### PR DESCRIPTION
## Description
This pull request introduces a new command to `coffee`, allowing users to list plugins in a remote repository.
## Example:
To list plugins in a remote repository, simply run:
```bash
coffee remote <repository_name> --plugins
```
## Changes
- [x] Added a new HTTP endpoint to handle the command.
- [x] Implemented test cases to ensure the functionality is reliable.
- [x] Documented the new command and its usage.
