### PR TITLE
Enhance `coffee_httpd` Test Structure and Remove Redundant Type Definitions

### DIFF
--- a/coffee_lib/src/types/mod.rs
+++ b/coffee_lib/src/types/mod.rs
@@ -6,44 +6,6 @@ pub mod request {
     use paperclip::actix::Apiv2Schema;
     use serde::{Deserialize, Serialize};
 
-    #[cfg(not(feature = "open-api"))]
-    #[derive(Debug, Deserialize, Serialize)]
-    pub struct Install {
-        pub plugin: String,
-        pub try_dynamic: bool,
-    }
-
-    #[cfg(not(feature = "open-api"))]
-    #[derive(Debug, Deserialize, Serialize)]
-    pub struct Remove {
-        pub plugin: String,
-    }
-
-    #[cfg(not(feature = "open-api"))]
-    #[derive(Debug, Deserialize, Serialize)]
-    pub struct RemoteAdd {
-        pub repository_name: String,
-        pub repository_url: String,
-    }
-
-    #[cfg(not(feature = "open-api"))]
-    #[derive(Debug, Deserialize, Serialize)]
-    pub struct RemoteRm {
-        pub repository_name: String,
-    }
-
-    #[cfg(not(feature = "open-api"))]
-    #[derive(Debug, Deserialize, Serialize)]
-    pub struct Show {
-        pub plugin: String,
-    }
-
-    #[cfg(not(feature = "open-api"))]
-    #[derive(Debug, Deserialize, Serialize)]
-    pub struct Search {
-        pub plugin: String,
-    }
-
     #[cfg(feature = "open-api")]
     #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
     pub struct Install {

--- a/tests/src/coffee_httpd_integration_tests.rs
+++ b/tests/src/coffee_httpd_integration_tests.rs
@@ -103,6 +103,157 @@ pub async fn httpd_add_remove_plugins() {
     let body = response.text().await.unwrap();
     log::info!("/remote/add response: {}", body);
 
+    // Define the request body to be sent to the /install endpoint
+    let install_request = Install {
+        plugin: "summary".to_string(),
+        try_dynamic: false,
+    };
+
+    let response = client
+        .post(format!("{}/install", url))
+        .json(&install_request)
+        .send()
+        .await;
+    assert!(response.is_ok(), "{:?}", response);
+    let response = response.unwrap();
+
+    // Check the response status code, log the body.
+    let body = response.text().await.unwrap();
+    log::info!("/install response: {}", body);
+
+    let body = reqwest::get(format!("{}/remote/list", url)).await;
+    assert!(body.is_ok(), "{:?}", body);
+    let body = body.unwrap().json::<serde_json::Value>().await;
+    assert!(body.is_ok(), "{:?}", body);
+    let body = body.unwrap();
+
+    // Log the response body
+    log::info!("/remote/list response: {}", body);
+
+    // Assert that the "lightningd" remote repository exists in the response
+    let remotes = body["remotes"].as_array();
+    assert!(remotes.is_some(), "{:?}", remotes);
+    let remotes = remotes.unwrap();
+    assert!(
+        remotes
+            .iter()
+            .any(|repo| repo["local_name"] == "lightningd"),
+        "lightningd remote repository not found in the response"
+    );
+
+    let body = reqwest::get(format!("{}/list", url)).await;
+    assert!(body.is_ok(), "{:?}", body);
+    let body = body.unwrap().json::<serde_json::Value>().await;
+    assert!(body.is_ok(), "{:?}", body);
+    let body = body.unwrap();
+
+    // Log the response body
+    log::info!("/list response: {}", body);
+
+    // Assert that the "summary" plugin exist in the response
+    let plugins = body["plugins"].as_array();
+    assert!(plugins.is_some(), "{:?}", plugins);
+    let plugins = plugins.unwrap();
+    assert!(
+        plugins.iter().any(|plugin| plugin["name"] == "summary"),
+        "summary plugin not found in the response"
+    );
+
+    // Define the request body to be sent
+    let plugin_remove_request = Remove {
+        plugin: "summary".to_string(),
+    };
+
+    let response = client
+        .post(format!("{}/remove", url))
+        .json(&plugin_remove_request)
+        .send()
+        .await;
+    assert!(response.is_ok(), "{:?}", response);
+    let response = response.unwrap();
+
+    // Check the response status code, log the body.
+    assert!(response.status().is_success());
+    let body = response.text().await.unwrap();
+    log::info!("Response body: {}", body);
+
+    // Define the request body to be sent
+    let remote_rm_request = RemoteRm {
+        repository_name: "lightningd".to_string(),
+    };
+
+    // This should also remove the helpme plugin
+    let response = client
+        .post(format!("{}/remote/rm", url))
+        .json(&remote_rm_request)
+        .send()
+        .await;
+    assert!(response.is_ok(), "{:?}", response);
+    let response = response.unwrap();
+
+    // Check the response status code, log the body.
+    assert!(response.status().is_success());
+    let body = response.text().await.unwrap();
+    log::info!("/remote/rm response: {}", body);
+
+    let body = reqwest::get(format!("{}/remote/list", url)).await;
+    assert!(body.is_ok(), "{:?}", body);
+    let body = body.unwrap().json::<serde_json::Value>().await;
+    assert!(body.is_ok(), "{:?}", body);
+    let body = body.unwrap();
+
+    // Log the response body
+    log::info!("/remote/list response: {}", body);
+
+    // Assert that the "lightningd" remote repository doesn't exist in the response
+    let remotes = body["remotes"].as_array();
+    assert!(remotes.is_some(), "{:?}", remotes);
+    let remotes = remotes.unwrap();
+    assert!(
+        !(remotes
+            .iter()
+            .any(|repo| repo["local_name"] == "lightningd")),
+        "lightningd remote repository is found in the response while it should have been removed"
+    );
+
+    cln.stop().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ntest::timeout(560000)]
+pub async fn httpd_search_list_plugins() {
+    init();
+
+    let mut cln = Node::tmp("regtest").await.unwrap();
+    let lightning_dir = cln.rpc().getinfo().unwrap().ligthning_dir;
+    let lightning_dir = lightning_dir.strip_suffix("/regtest").unwrap();
+    let manager = CoffeeHTTPDTesting::tmp(lightning_dir.to_string()).await;
+    assert!(manager.is_ok(), "{:?}", manager);
+    let manager = manager.unwrap();
+    log::info!("lightning path: {lightning_dir}");
+    let url = manager.url();
+    log::info!("base url: {url}");
+    let client = reqwest::Client::new();
+
+    // Define the request body to be sent to the /remote/add endpoint
+    let remote_add_request = RemoteAdd {
+        repository_name: "lightningd".to_string(),
+        repository_url: "https://github.com/lightningd/plugins.git".to_string(),
+    };
+
+    let response = client
+        .post(format!("{}/remote/add", url))
+        .json(&remote_add_request)
+        .send()
+        .await;
+    assert!(response.is_ok(), "{:?}", response);
+    let response = response.unwrap();
+
+    // Check the response status code, log the body.
+    assert!(response.status().is_success());
+    let body = response.text().await.unwrap();
+    log::info!("/remote/add response: {}", body);
+
     // Define the request body to be sent to the /remote/list_plugins endpoint
     let remote_plugins_list_request = RemotePluginsList {
         repository_name: "lightningd".to_string(),
@@ -199,177 +350,5 @@ pub async fn httpd_add_remove_plugins() {
         "{:?}",
         repository_url
     );
-
-    // Define the request body to be sent to the /install endpoint
-    let install_request = Install {
-        plugin: "summary".to_string(),
-        try_dynamic: false,
-    };
-
-    let response = client
-        .post(format!("{}/install", url))
-        .json(&install_request)
-        .send()
-        .await;
-    assert!(response.is_ok(), "{:?}", response);
-    let response = response.unwrap();
-
-    // Check the response status code, log the body.
-    let body = response.text().await.unwrap();
-    log::info!("/install response: {}", body);
-
-    // Define the request body to be sent to the /install endpoint
-    let install_request = Install {
-        plugin: "helpme".to_string(),
-        try_dynamic: false,
-    };
-
-    let response = client
-        .post(format!("{}/install", url))
-        .json(&install_request)
-        .send()
-        .await;
-    assert!(response.is_ok(), "{:?}", response);
-    let response = response.unwrap();
-
-    // Check the response status code, log the body.
-    let body = response.text().await.unwrap();
-    log::info!("/install response: {}", body);
-
-    let body = reqwest::get(format!("{}/remote/list", url)).await;
-    assert!(body.is_ok(), "{:?}", body);
-    let body = body.unwrap().json::<serde_json::Value>().await;
-    assert!(body.is_ok(), "{:?}", body);
-    let body = body.unwrap();
-
-    // Log the response body
-    log::info!("/remote/list response: {}", body);
-
-    // Assert that the "lightningd" remote repository exists in the response
-    let remotes = body["remotes"].as_array();
-    assert!(remotes.is_some(), "{:?}", remotes);
-    let remotes = remotes.unwrap();
-    assert!(
-        remotes
-            .iter()
-            .any(|repo| repo["local_name"] == "lightningd"),
-        "lightningd remote repository not found in the response"
-    );
-
-    let body = reqwest::get(format!("{}/list", url)).await;
-    assert!(body.is_ok(), "{:?}", body);
-    let body = body.unwrap().json::<serde_json::Value>().await;
-    assert!(body.is_ok(), "{:?}", body);
-    let body = body.unwrap();
-
-    // Log the response body
-    log::info!("/list response: {}", body);
-
-    // Assert that the "helpme" and "summary" plugin exist in the response
-    let plugins = body["plugins"].as_array();
-    assert!(plugins.is_some(), "{:?}", plugins);
-    let plugins = plugins.unwrap();
-    assert!(
-        plugins.iter().any(|plugin| plugin["name"] == "helpme"),
-        "helpme plugin not found in the response"
-    );
-    assert!(
-        plugins.iter().any(|plugin| plugin["name"] == "summary"),
-        "summary plugin not found in the response"
-    );
-
-    // Define the request body to be sent
-    let plugin_remove_request = Remove {
-        plugin: "summary".to_string(),
-    };
-
-    let response = client
-        .post(format!("{}/remove", url))
-        .json(&plugin_remove_request)
-        .send()
-        .await;
-    assert!(response.is_ok(), "{:?}", response);
-    let response = response.unwrap();
-
-    // Check the response status code, log the body.
-    assert!(response.status().is_success());
-    let body = response.text().await.unwrap();
-    log::info!("Response body: {}", body);
-
-    let body = reqwest::get(format!("{}/list", url)).await;
-    assert!(body.is_ok(), "{:?}", body);
-    let body = body.unwrap().json::<serde_json::Value>().await;
-    assert!(body.is_ok(), "{:?}", body);
-    let body = body.unwrap();
-
-    // Log the response body
-    log::info!("/list response: {}", body);
-
-    // Assert that the "summary" plugin was removed
-    let plugins = body["plugins"].as_array();
-    assert!(plugins.is_some(), "{:?}", plugins);
-    let plugins = plugins.unwrap();
-    assert!(
-        !(plugins.iter().any(|plugin| plugin["name"] == "summary")),
-        "summary plugin is found in the list response while it should have been removed"
-    );
-
-    // Define the request body to be sent
-    let remote_rm_request = RemoteRm {
-        repository_name: "lightningd".to_string(),
-    };
-
-    // This should also remove the helpme plugin
-    let response = client
-        .post(format!("{}/remote/rm", url))
-        .json(&remote_rm_request)
-        .send()
-        .await;
-    assert!(response.is_ok(), "{:?}", response);
-    let response = response.unwrap();
-
-    // Check the response status code, log the body.
-    assert!(response.status().is_success());
-    let body = response.text().await.unwrap();
-    log::info!("/remote/rm response: {}", body);
-
-    let body = reqwest::get(format!("{}/list", url)).await;
-    assert!(body.is_ok(), "{:?}", body);
-    let body = body.unwrap().json::<serde_json::Value>().await;
-    assert!(body.is_ok(), "{:?}", body);
-    let body = body.unwrap();
-
-    // Log the response body
-    log::info!("/list response: {}", body);
-
-    // Assert that the "helpme" plugin was removed
-    let plugins = body["plugins"].as_array();
-    assert!(plugins.is_some(), "{:?}", plugins);
-    let plugins = plugins.unwrap();
-    assert!(
-        !(plugins.iter().any(|plugin| plugin["name"] == "helpme")),
-        "helpme plugin is found in the list response while it should have been removed"
-    );
-
-    let body = reqwest::get(format!("{}/remote/list", url)).await;
-    assert!(body.is_ok(), "{:?}", body);
-    let body = body.unwrap().json::<serde_json::Value>().await;
-    assert!(body.is_ok(), "{:?}", body);
-    let body = body.unwrap();
-
-    // Log the response body
-    log::info!("/remote/list response: {}", body);
-
-    // Assert that the "lightningd" remote repository doesn't exist in the response
-    let remotes = body["remotes"].as_array();
-    assert!(remotes.is_some(), "{:?}", remotes);
-    let remotes = remotes.unwrap();
-    assert!(
-        !(remotes
-            .iter()
-            .any(|repo| repo["local_name"] == "lightningd")),
-        "lightningd remote repository is found in the response while it should have been removed"
-    );
-
     cln.stop().await.unwrap();
 }


### PR DESCRIPTION
# Description
- This PR enhances the testing structure in `coffee_httpd` by breaking down the test into two.
	- All `http` endpoints are tested 
		- In the `httpd_add_remove_plugins` test, we test endpoints like `/remote/add`, `/install`, `/remote/list`, `/list`, `/remove`, and `/remote/rm`
		- In `httpd_search_list_plugins`, we test (`/remote/list_plugins`, `/show`, `/search`)
- Additionally, this PR eliminates redundant `request` type definitions found in `coffee_lib/src/types/mod.rs`

Related issue: #202

Fixes https://github.com/coffee-tools/coffee/issues/202