### PR TITLE
Improved Coffee Verification and CoffeeNurse Functionality

### DIFF
--- a/coffee_cmd/src/cmd.rs
+++ b/coffee_cmd/src/cmd.rs
@@ -14,6 +14,8 @@ pub struct CoffeeArgs {
     pub network: Option<String>,
     #[clap(short, long, value_parser, name = "data-dir")]
     pub data_dir: Option<String>,
+    #[clap(short, long, action = clap::ArgAction::SetTrue)]
+    pub skip_verify: bool,
 }
 
 /// Coffee subcommand of the command line daemon.
@@ -59,7 +61,11 @@ pub enum CoffeeCommand {
     Search { plugin: String },
     /// clean up remote repositories storage information
     #[clap(arg_required_else_help = false)]
-    Nurse {},
+    Nurse {
+        /// verify that coffee configuration is sane (without taking any action)
+        #[arg(short, long, action = clap::ArgAction::SetTrue)]
+        verify: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -96,7 +102,7 @@ impl From<&CoffeeCommand> for coffee_core::CoffeeOperation {
             CoffeeCommand::Remove { plugin } => Self::Remove(plugin.to_owned()),
             CoffeeCommand::Show { plugin } => Self::Show(plugin.to_owned()),
             CoffeeCommand::Search { plugin } => Self::Search(plugin.to_owned()),
-            CoffeeCommand::Nurse {} => Self::Nurse,
+            CoffeeCommand::Nurse { verify } => Self::Nurse(*verify),
         }
     }
 }
@@ -126,5 +132,9 @@ impl coffee_core::CoffeeArgs for CoffeeArgs {
 
     fn network(&self) -> Option<String> {
         self.network.clone()
+    }
+
+    fn skip_verify(&self) -> bool {
+        self.skip_verify
     }
 }

--- a/coffee_cmd/src/coffee_term/command_show.rs
+++ b/coffee_cmd/src/coffee_term/command_show.rs
@@ -84,7 +84,7 @@ pub fn show_nurse_result(
         Ok(nurse) => {
             // special case: if the nurse is sane
             // we print a message and return
-            if nurse.status[0] == NurseStatus::Sane {
+            if nurse.is_sane() {
                 term::success!("Coffee configuration is not corrupt! No need to run coffee nurse");
                 return Ok(());
             }
@@ -98,14 +98,12 @@ pub fn show_nurse_result(
 
             for status in &nurse.status {
                 let action_str = match status {
-                    NurseStatus::Sane => "".to_string(),
                     NurseStatus::RepositoryLocallyRestored(_) => "Restored using Git".to_string(),
                     NurseStatus::RepositoryLocallyRemoved(_) => {
                         "Removed from local storage".to_string()
                     }
                 };
                 let repos_str = match status {
-                    NurseStatus::Sane => "".to_string(),
                     NurseStatus::RepositoryLocallyRestored(repos)
                     | NurseStatus::RepositoryLocallyRemoved(repos) => repos.join(", "),
                 };

--- a/coffee_cmd/src/main.rs
+++ b/coffee_cmd/src/main.rs
@@ -160,9 +160,18 @@ async fn main() -> Result<(), CoffeeError> {
             }
             Err(err) => Err(err),
         },
-        CoffeeCommand::Nurse {} => {
-            let nurse_result = coffee.nurse().await;
-            coffee_term::show_nurse_result(nurse_result)
+        CoffeeCommand::Nurse { verify } => {
+            if verify {
+                let result = coffee.nurse_verify().await?;
+                term::info!("{}", result);
+                if !result.is_sane() {
+                    term::info!("Coffee local directory is damaged, please run `coffee nurse` to try to fix it");
+                }
+                Ok(())
+            } else {
+                let nurse_result = coffee.nurse().await;
+                coffee_term::show_nurse_result(nurse_result)
+            }
         }
     };
 

--- a/coffee_core/src/config.rs
+++ b/coffee_core/src/config.rs
@@ -3,6 +3,7 @@ use log::info;
 use serde::{Deserialize, Serialize};
 use std::env;
 
+use crate::CoffeeOperation;
 use coffee_lib::utils::check_dir_or_make_if_missing;
 use coffee_lib::{errors::CoffeeError, plugin::Plugin};
 
@@ -28,6 +29,10 @@ pub struct CoffeeConf {
     /// all plugins that are installed
     /// with the plugin manager.
     pub plugins: Vec<Plugin>,
+    /// A flag that indicates if the
+    /// user wants to skip the verification
+    /// of nurse.
+    pub skip_verify: bool,
 }
 
 impl CoffeeConf {
@@ -51,6 +56,7 @@ impl CoffeeConf {
             plugins: vec![],
             cln_config_path: None,
             cln_root: None,
+            skip_verify: false,
         };
 
         // check the command line arguments and bind them
@@ -80,6 +86,20 @@ impl CoffeeConf {
 
         if let Some(config) = &conf.conf() {
             self.config_path = config.to_owned();
+        }
+
+        // If the command is nurse we skip the verification
+        // because nurse is the command that needs
+        // to solve the configuration problems.
+        if !conf.skip_verify() {
+            match conf.command() {
+                CoffeeOperation::Nurse(_) => {
+                    self.skip_verify = true;
+                }
+                _ => {
+                    self.skip_verify = false;
+                }
+            }
         }
 
         // FIXME: be able to put the directory also in another place!

--- a/coffee_core/src/lib.rs
+++ b/coffee_core/src/lib.rs
@@ -21,7 +21,7 @@ pub enum CoffeeOperation {
     Show(String),
     /// Search(plugin name)
     Search(String),
-    Nurse,
+    Nurse(bool),
 }
 
 #[derive(Clone, Debug)]
@@ -40,4 +40,6 @@ pub trait CoffeeArgs: Send + Sync {
     fn network(&self) -> Option<String>;
     /// return the data dir
     fn data_dir(&self) -> Option<String>;
+    /// return the skip verify flag
+    fn skip_verify(&self) -> bool;
 }

--- a/coffee_httpd/src/cmd.rs
+++ b/coffee_httpd/src/cmd.rs
@@ -36,4 +36,11 @@ impl coffee_core::CoffeeArgs for HttpdArgs {
     fn network(&self) -> Option<String> {
         self.network.clone()
     }
+
+    // We don't need to verify the nurse in the httpd
+    // daemon.
+    // there is no endpoint for `nurse` in the httpd
+    fn skip_verify(&self) -> bool {
+        true
+    }
 }

--- a/coffee_lib/src/plugin_manager.rs
+++ b/coffee_lib/src/plugin_manager.rs
@@ -52,6 +52,9 @@ pub trait PluginManager {
     /// clean up storage information about the remote repositories of the plugin manager.
     async fn nurse(&mut self) -> Result<CoffeeNurse, CoffeeError>;
 
+    /// verify that coffee configuration is sane without taking any action.
+    async fn nurse_verify(&self) -> Result<ChainOfResponsibilityStatus, CoffeeError>;
+
     /// patch coffee configuration in the case that a repository is present in the coffee
     /// configuration but is absent from the local storage.
     async fn patch_repository_locally_absent(

--- a/coffee_lib/src/types/mod.rs
+++ b/coffee_lib/src/types/mod.rs
@@ -154,7 +154,7 @@ pub mod response {
 
     /// This struct is used to represent a defect
     /// that can be patched by the nurse.
-    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
     pub enum Defect {
         // A patch operation when a git repository is present in the coffee configuration
         // but is absent from the local storage.
@@ -167,12 +167,38 @@ pub mod response {
         pub defects: Vec<Defect>,
     }
 
+    impl ChainOfResponsibilityStatus {
+        pub fn is_sane(&self) -> bool {
+            self.defects.is_empty()
+        }
+    }
+
+    impl fmt::Display for ChainOfResponsibilityStatus {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            if self.defects.is_empty() {
+                write!(f, "Coffee is sane")
+            } else {
+                writeln!(f, "Coffee has the following defects:")?;
+                for (i, defect) in self.defects.iter().enumerate() {
+                    match defect {
+                        Defect::RepositoryLocallyAbsent(repos) => {
+                            write!(f, "{}. Repository missing locally: ", i + 1)?;
+                            for repo in repos {
+                                write!(f, " {}", repo)?;
+                            }
+                        }
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+
     /// This struct is used to represent the status of nurse,
     /// either sane or not.
     /// If not sane, return the action that nurse has taken.
     #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
     pub enum NurseStatus {
-        Sane,
         RepositoryLocallyRestored(Vec<String>),
         RepositoryLocallyRemoved(Vec<String>),
     }
@@ -182,13 +208,44 @@ pub mod response {
         pub status: Vec<NurseStatus>,
     }
 
+    impl CoffeeNurse {
+        pub fn is_sane(&self) -> bool {
+            self.status.is_empty()
+        }
+
+        pub fn organize(&mut self) {
+            // For every action taken by the nurse, we want to
+            // have 1 entry with the list of repositories affected.
+            let mut new_status: Vec<NurseStatus> = vec![];
+            let mut repositories_locally_removed: Vec<String> = vec![];
+            let mut repositories_locally_restored: Vec<String> = vec![];
+            for repo in self.status.iter() {
+                match repo {
+                    NurseStatus::RepositoryLocallyRemoved(repos) => {
+                        repositories_locally_removed.append(&mut repos.clone())
+                    }
+                    NurseStatus::RepositoryLocallyRestored(repos) => {
+                        repositories_locally_restored.append(&mut repos.clone())
+                    }
+                }
+            }
+            if !repositories_locally_removed.is_empty() {
+                new_status.push(NurseStatus::RepositoryLocallyRemoved(
+                    repositories_locally_removed,
+                ));
+            }
+            if !repositories_locally_restored.is_empty() {
+                new_status.push(NurseStatus::RepositoryLocallyRestored(
+                    repositories_locally_restored,
+                ));
+            }
+            self.status = new_status;
+        }
+    }
+
     impl fmt::Display for NurseStatus {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             match self {
-                NurseStatus::Sane => write!(
-                    f,
-                    "coffee configuration is not corrupt! No need to run coffee nurse"
-                ),
                 NurseStatus::RepositoryLocallyRestored(val) => {
                     write!(f, "Repositories restored locally: {}", val.join(" "))
                 }

--- a/coffee_plugin/src/plugin/state.rs
+++ b/coffee_plugin/src/plugin/state.rs
@@ -75,6 +75,11 @@ impl CoffeeArgs for PluginArgs {
     fn network(&self) -> Option<String> {
         Some(self.network.clone())
     }
+
+    // we don't need to verify the nurse
+    fn skip_verify(&self) -> bool {
+        true
+    }
 }
 
 impl From<CLNConf> for PluginArgs {

--- a/coffee_testing/src/lib.rs
+++ b/coffee_testing/src/lib.rs
@@ -95,6 +95,10 @@ impl coffee_core::CoffeeArgs for CoffeeTestingArgs {
     fn network(&self) -> Option<String> {
         Some(self.network.clone())
     }
+
+    fn skip_verify(&self) -> bool {
+        true
+    }
 }
 
 /// Coffee testing manager

--- a/docs/docs-book/src/using-coffee.md
+++ b/docs/docs-book/src/using-coffee.md
@@ -37,6 +37,7 @@ the correct network.
 - `--data-dir`: by default set to `/home/alice/.coffee`, you may want to set
 this option if you are looking to specify a different directory for the
 Coffee home.
+- `--skip-verify`: Use this option to bypass `coffee`'s validation process, which checks for conflicts between its configuration and the local storage.
 
 ### Add a Plugin Repository
 
@@ -151,6 +152,11 @@ coffee search <plugin_name>
 
 ```bash
 coffee nurse
+```
+Additionally, if you wish to perform a verification of coffee without making any changes, you can use the `--verify` flag:
+
+```bash
+coffee nurse --verify
 ```
 _________
 ## Running coffee as a server


### PR DESCRIPTION
# Description
This pull request introduces enhancements to `coffee` command-line tool:

### 1. Verification Enhancements:
- `coffee` now checks the status of its configuration before executing each command.
- If the configuration is found to be in an unsatisfactory state, the command will return an error.
- To bypass this verification step, users can employ the `--skip-verify` flag.

### 2. CoffeeNurse Improvements:
- Implemented `is_sane` for `CoffeeNurse` type to assess the sanity of the `coffee` configuration.
- Introduced the `organize` method for `CoffeeNurse`, ensuring each action is included only once.
- Added a new method, `coffee_verify`, which allows users to check `coffee` configuration's status without taking any action.

### 3. New `--verify` Flag:
- The `coffee nurse` command now supports a `--verify` flag, which invokes the `coffee_verify` method.

### 4. Testing and Documentation:
- Included a test case for the `coffee_verify` method.
- Updated documentation to reflect these enhancements.

Fixes #128 