### PR TITLE
Enhance Error Message for Missing Core Lightning Configuration File

### DIFF
--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -195,10 +195,12 @@ impl CoffeeManager {
         if self.config.cln_config_path.is_none() {
             return Ok(());
         }
-        let root = self.config.cln_root.clone().unwrap();
+        let root = self.config.cln_root.clone();
+        let root = root.ok_or_else(|| error!("cln root path not found."))?;
         let rpc = Client::new(format!("{root}/{}/lightning-rpc", self.config.network));
         self.rpc = Some(rpc);
-        let path = self.config.cln_config_path.clone().unwrap();
+        let path = self.config.cln_config_path.clone();
+        let path = path.ok_or_else(|| error!("cln config path not found."))?;
         let mut file = CLNConf::new(path.clone(), true);
         log::info!("looking for the cln config: {path}");
         file.parse()
@@ -217,7 +219,8 @@ impl CoffeeManager {
         self.config.cln_config_path = Some(path_with_network);
         self.config.cln_root = Some(cln_dir.to_owned());
         self.load_cln_conf().await?;
-        let mut conf = self.cln_config.clone().unwrap();
+        let conf = self.cln_config.clone();
+        let mut conf = conf.ok_or_else(|| error!("cln config path not found."))?;
         conf.add_subconf(self.coffee_cln_config.clone())
             .map_err(|err| error!("{}", &err.cause))?;
         conf.flush()?;

--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::path::Path;
 use std::vec::Vec;
 use tokio::fs;
 
@@ -201,6 +202,17 @@ impl CoffeeManager {
         self.rpc = Some(rpc);
         let path = self.config.cln_config_path.clone();
         let path = path.ok_or_else(|| error!("cln config path not found."))?;
+
+        // The path is the path of the cln config file (eg. ~/.lightning/bitcoin/config)
+        // We need to check that the root folder (eg. ~/.lightning/bitcoin) exists
+        // otherwise we return an error.
+
+        // We can unwrap here because we are sure that the path ends with /config
+        let lightning_path = path.strip_suffix("/config").unwrap();
+        if !Path::new(&lightning_path).exists() {
+            return Err(error!("The path {lightning_path} does not exist"));
+        }
+
         let mut file = CLNConf::new(path.clone(), true);
         log::info!("looking for the cln config: {path}");
         file.parse()


### PR DESCRIPTION
The error message displayed in case of a missing Core Lightning configuration file has been enhanced to provide users with more friendly and actionable information.

Now, when coffee fails to find the configuration file at the specified path, it advises users to resolve the issue by running the `coffee setup <cln_path>` command, helping them quickly address the problem and proceed smoothly.


Fixes #209 