### PR TITLE
Add `Derive` Feature to `Clap` in `coffee_httpd` `Cargo.toml`

### DIFF
--- a/coffee_httpd/Cargo.toml
+++ b/coffee_httpd/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 actix-web = "4"
-clap = "4.1.11"
+clap = { version = "4.1.11", features = ["derive"] }
 tokio = { version = "1.22.0", features = ["sync"] }
 coffee_core = { path = "../coffee_core" }
 coffee_lib = { path = "../coffee_lib", features = ["open-api"] }


### PR DESCRIPTION
## Changes:
- Added the `Derive` feature to clap in `coffee_httpd/Cargo.toml`
## Description:
This pull request resolves an issue where the `coffee_httpd` crate was unable to compile on its own. The changes specifically adds the `Derive` feature to clap in the `coffee_httpd/Cargo.toml` file.
Here is a related discussion https://github.com/rust-lang/cargo/issues/11551 

Fixes #215 