### PR TITLE
fix(cmd): check if the ln path that we know are good

### DIFF
--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -196,6 +196,16 @@ impl CoffeeManager {
             return Ok(());
         }
         let root = self.config.cln_root.clone().unwrap();
+        // We check if there is some problem we the path that we know
+        if !fs::try_exists(root.clone()).await? {
+            return Err(error!("lightning root path `{}` do not exist", root));
+        } else if !fs::try_exists(format!("{root}/{}", self.config.network)).await? {
+            return Err(error!(
+                "lightning network path `{root}/{}` do not exist",
+                self.config.network
+            ));
+        }
+        // All safe, we can move with the logic
         let rpc = Client::new(format!("{root}/{}/lightning-rpc", self.config.network));
         self.rpc = Some(rpc);
         let path = self.config.cln_config_path.clone().unwrap();


### PR DESCRIPTION
Sometimes we may do operations like delete a directory that is linked with coffee, but we forget it.

So this code makes sure that we are operating on a piece of safe information.

Fixes https://github.com/coffee-tools/coffee/issues/209

Alternative to https://github.com/coffee-tools/coffee/pull/211 this should fix the real problem