### PR TITLE
fix: typo and docs link

### DIFF
--- a/docs/docs-book/src/install-coffee.md
+++ b/docs/docs-book/src/install-coffee.md
@@ -18,7 +18,7 @@ make install
 coffee --help
 ```
 
-You can also install `coffee_httpd` binary to [run coffee as a server](../src/using-coffee.md#running-coffee-as-a-server). run:
+You can also install `coffee_httpd` binary to [run coffee as a server](../using-coffee.md#running-coffee-as-a-server). run:
 ```bash
 cargo install --bin coffee_httpd
 ```

--- a/docs/docs-book/src/using-coffee.md
+++ b/docs/docs-book/src/using-coffee.md
@@ -22,7 +22,7 @@ coffee setup /home/alice/.lightning
 ```
 
 Then you will find an include at the end of the config file at
-`/home/alice/.lightnig/bitcoin/config`, in case this config file do not exist
+`/home/alice/.lightning/bitcoin/config`, in case this config file do not exist
 Coffee will create it.
 
 ```text


### PR DESCRIPTION
The link was previously showing 404 error, fixed it. Also, a minor typo in the docs.