### PR TITLE
Add `coffee disable` and `coffee enable` Commands

### DIFF
--- a/coffee_cmd/src/cmd.rs
+++ b/coffee_cmd/src/cmd.rs
@@ -73,6 +73,12 @@ pub enum CoffeeCommand {
     /// tipping a plugins developer.
     #[clap(arg_required_else_help = false)]
     Tip { plugin: String, amount_msat: u64 },
+    /// Disable a plugin
+    #[clap(arg_required_else_help = true)]
+    Disable { plugin: String },
+    /// Enable a plugin
+    #[clap(arg_required_else_help = true)]
+    Enable { plugin: String },
 }
 
 #[derive(Debug, Subcommand)]
@@ -114,6 +120,8 @@ impl From<&CoffeeCommand> for coffee_core::CoffeeOperation {
                 plugin,
                 amount_msat,
             } => Self::Tip(plugin.to_owned(), amount_msat.clone()),
+            CoffeeCommand::Disable { plugin } => Self::Disable(plugin.to_owned()),
+            CoffeeCommand::Enable { plugin } => Self::Enable(plugin.to_owned()),
         }
     }
 }

--- a/coffee_cmd/src/coffee_term/command_show.rs
+++ b/coffee_cmd/src/coffee_term/command_show.rs
@@ -14,22 +14,31 @@ pub fn show_list(coffee_list: Result<CoffeeList, CoffeeError>) -> Result<(), Cof
 
     term::println(
         term::format::bold("●"),
-        term::format::tertiary("Plugin installed"),
+        term::format::tertiary("Plugins installed"),
     );
     let mut table = radicle_term::Table::new(TableOptions::bordered());
     table.push([
         term::format::dim(String::from("●")),
         term::format::bold(String::from("Language")),
         term::format::bold(String::from("Name")),
+        term::format::bold(String::from("Enabled?")),
         term::format::bold(String::from("Exec path")),
     ]);
     table.divider();
 
     for plugin in &remotes.plugins {
+        // Get whether the plugin is enabled
+        // If enabled is None, it means the plugin is enabled by default for backward compatibility.
+        let enabled = plugin.enabled.unwrap_or(true);
         table.push([
             term::format::positive("●").into(),
             term::format::highlight(plugin.lang.to_string()),
             term::format::bold(plugin.name()),
+            if enabled {
+                term::format::positive("yes").into()
+            } else {
+                term::format::negative("no").into()
+            },
             term::format::highlight(plugin.exec_path.to_owned()),
         ])
     }

--- a/coffee_cmd/src/coffee_term/command_show.rs
+++ b/coffee_cmd/src/coffee_term/command_show.rs
@@ -21,7 +21,7 @@ pub fn show_list(coffee_list: Result<CoffeeList, CoffeeError>) -> Result<(), Cof
         term::format::dim(String::from("●")),
         term::format::bold(String::from("Language")),
         term::format::bold(String::from("Name")),
-        term::format::bold(String::from("Enabled?")),
+        term::format::bold(String::from("Enabled")),
         term::format::bold(String::from("Exec path")),
     ]);
     table.divider();

--- a/coffee_cmd/src/main.rs
+++ b/coffee_cmd/src/main.rs
@@ -176,6 +176,14 @@ async fn run(args: CoffeeArgs, mut coffee: CoffeeManager) -> Result<(), CoffeeEr
             let tip_result = coffee.tip(&plugin, amount_msat).await?;
             coffee_term::show_tips(&tip_result)?;
         }
+        CoffeeCommand::Disable { plugin } => {
+            coffee.disable(&plugin).await?;
+            term::success!("Plugin {plugin} disabled");
+        }
+        CoffeeCommand::Enable { plugin } => {
+            coffee.enable(&plugin).await?;
+            term::success!("Plugin {plugin} enabled");
+        }
     };
     Ok(())
 }

--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -614,7 +614,7 @@ impl PluginManager for CoffeeManager {
             return Err(error!("Plugin `{plugin}` is already disabled"));
         }
         self.coffee_cln_config
-            .rm_conf("plugin", Some(&plugin.exec_path))
+            .add_conf("disable-plugin", &plugin.exec_path)
             .map_err(|err| error!("{}", err.cause))?;
         log::debug!(
             "Plugin {} was removed from CLN configuration successfully",
@@ -646,7 +646,7 @@ impl PluginManager for CoffeeManager {
             ));
         }
         self.coffee_cln_config
-            .add_conf("plugin", &plugin.exec_path)
+            .rm_conf("disable-plugin", Some(&plugin.exec_path))
             .map_err(|err| error!("{}", err.cause))?;
         log::debug!(
             "Plugin {} was added to CLN configuration successfully",

--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -289,6 +289,8 @@ impl PluginManager for CoffeeManager {
                         let path = plugin.configure(verbose).await?;
                         log::debug!("runnable plugin path {path}");
                         if !try_dynamic {
+                            // mark the plugin enabled
+                            plugin.enabled = Some(true);
                             self.config.plugins.push(plugin);
                             log::debug!("path coffee conf: {}", self.coffee_cln_config.path);
                             self.coffee_cln_config

--- a/coffee_core/src/lib.rs
+++ b/coffee_core/src/lib.rs
@@ -26,6 +26,10 @@ pub enum CoffeeOperation {
     ///
     /// (plugin_name, amount_msat)
     Tip(String, u64),
+    /// Disable a plugin(plugin name)
+    Disable(String),
+    /// Enable a plugin(plugin name)
+    Enable(String),
 }
 
 #[derive(Clone, Debug)]

--- a/coffee_github/src/repository.rs
+++ b/coffee_github/src/repository.rs
@@ -186,6 +186,9 @@ impl Github {
                         plugin_lang,
                         conf.clone(),
                         commit_id.clone(),
+                        // The plugin for now is not installed, so it's
+                        // neither enabled or disabled
+                        None,
                     );
 
                     debug!("new plugin: {:?}", plugin);

--- a/coffee_httpd/src/httpd/server.rs
+++ b/coffee_httpd/src/httpd/server.rs
@@ -62,6 +62,8 @@ pub async fn run_httpd<T: ToSocketAddrs>(
             .service(coffee_show)
             .service(coffee_search)
             .service(coffee_list_plugins_in_remote)
+            .service(coffee_disable)
+            .service(coffee_enable)
             .with_json_spec_at("/api/v1")
             .build()
     })
@@ -196,6 +198,34 @@ async fn coffee_search(
     let result = coffee.search(plugin).await;
 
     handle_httpd_response!(result)
+}
+
+#[api_v2_operation]
+#[post("/disable")]
+async fn coffee_disable(
+    data: web::Data<AppState>,
+    body: Json<Disable>,
+) -> Result<HttpResponse, Error> {
+    let plugin = &body.plugin;
+
+    let mut coffee = data.coffee.lock().await;
+    let result = coffee.disable(plugin).await;
+
+    handle_httpd_response!(result, "Plugin '{plugin}' disabled successfully")
+}
+
+#[api_v2_operation]
+#[post("/enable")]
+async fn coffee_enable(
+    data: web::Data<AppState>,
+    body: Json<Enable>,
+) -> Result<HttpResponse, Error> {
+    let plugin = &body.plugin;
+
+    let mut coffee = data.coffee.lock().await;
+    let result = coffee.enable(plugin).await;
+
+    handle_httpd_response!(result, "Plugin '{plugin}' enabled successfully")
 }
 
 // this is just a hack to support swagger UI with https://paperclip-rs.github.io/paperclip/

--- a/coffee_lib/src/plugin.rs
+++ b/coffee_lib/src/plugin.rs
@@ -104,6 +104,8 @@ pub struct Plugin {
     conf: Option<Conf>,
     /// FIXME: this field shouldn't be optional
     pub commit: Option<String>,
+    /// Optional for now to be backward compatible
+    pub enabled: Option<bool>,
 }
 
 impl Plugin {
@@ -115,6 +117,7 @@ impl Plugin {
         plugin_lang: PluginLang,
         config: Option<Conf>,
         commit_id: Option<String>,
+        enabled: Option<bool>,
     ) -> Self {
         Plugin {
             name: name.to_owned(),
@@ -123,6 +126,7 @@ impl Plugin {
             lang: plugin_lang,
             conf: config,
             commit: commit_id,
+            enabled,
         }
     }
 

--- a/coffee_lib/src/plugin.rs
+++ b/coffee_lib/src/plugin.rs
@@ -104,7 +104,8 @@ pub struct Plugin {
     conf: Option<Conf>,
     /// FIXME: this field shouldn't be optional
     pub commit: Option<String>,
-    /// Optional for now to be backward compatible
+    // Optional for now to be backward compatible
+    /// If the plugin is enabled or not
     pub enabled: Option<bool>,
 }
 

--- a/coffee_lib/src/plugin_manager.rs
+++ b/coffee_lib/src/plugin_manager.rs
@@ -69,4 +69,10 @@ pub trait PluginManager {
     ///
     /// P.S: only Bitcoin ofc
     async fn tip(&mut self, plugin: &str, amount_msat: u64) -> Result<CoffeeTip, CoffeeError>;
+
+    /// disable a plugin by name
+    async fn disable(&mut self, plugin: &str) -> Result<(), CoffeeError>;
+
+    /// enable a plugin by name
+    async fn enable(&mut self, plugin: &str) -> Result<(), CoffeeError>;
 }

--- a/coffee_lib/src/types/mod.rs
+++ b/coffee_lib/src/types/mod.rs
@@ -49,6 +49,18 @@ pub mod request {
     pub struct Search {
         pub plugin: String,
     }
+
+    #[cfg(feature = "open-api")]
+    #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
+    pub struct Disable {
+        pub plugin: String,
+    }
+
+    #[cfg(feature = "open-api")]
+    #[derive(Debug, Deserialize, Apiv2Schema, Serialize)]
+    pub struct Enable {
+        pub plugin: String,
+    }
 }
 
 // Definition of the response types.

--- a/docs/docs-book/src/using-coffee.md
+++ b/docs/docs-book/src/using-coffee.md
@@ -32,11 +32,11 @@ include /home/alice/.coffee/testnet/coffee.conf
 In addition there are the following additional option that you can specify:
 
 - `--network`: by default set to `bitcoin`, but if you want to specify the network
-that Core Lightning is using, you must ensure that the flag is set to
-the correct network.
+  that Core Lightning is using, you must ensure that the flag is set to
+  the correct network.
 - `--data-dir`: by default set to `/home/alice/.coffee`, you may want to set
-this option if you are looking to specify a different directory for the
-Coffee home.
+  this option if you are looking to specify a different directory for the
+  Coffee home.
 - `--skip-verify`: Use this option to bypass `coffee`'s validation process, which checks for conflicts between its configuration and the local storage.
 
 ### Add a Plugin Repository
@@ -66,7 +66,7 @@ To list plugin repositories, simply run the following command.
 > ✅ Implemented
 
 ```bash
-coffee remote list 
+coffee remote list
 ```
 
 To list available plugins in a specific remote repository
@@ -114,10 +114,34 @@ To remove an installed plugin, you simply have to run the following command.
 coffee remove <plugin_name>
 ```
 
+### Disabling a Plugin
+
+> ✅ Implemented
+
+Disabling a plugin means that the plugin will not be loaded with CLN but it will still be installed and can be enabled at any time.
+
+To disable a plugin, run:
+
+```bash
+coffee disable <plugin_name>
+```
+
+### Enabling a Plugin
+
+> ✅ Implemented
+
+To enable a plugin, run:
+
+```bash
+coffee enable <plugin_name>
+```
+
 ### Upgrade a Plugin
 
 Coffee tightly integrates with git, allowing you to easily upgrade your plugins through the command line interface (CLI). This eliminates the need for tedious tasks such as downloading the latest updates and creating new versions of plugins. To upgrade a plugin, all you need to do is run.
+
 > ✅ Implemented
+
 ```bash
 coffee upgrade <repo_name>
 ```
@@ -138,7 +162,7 @@ coffee list
 coffee show <plugin_name>
 ```
 
-### Searching for a plugin in remote repositories 
+### Searching for a plugin in remote repositories
 
 > ✅ Implemented
 
@@ -153,12 +177,15 @@ coffee search <plugin_name>
 ```bash
 coffee nurse
 ```
+
 Additionally, if you wish to perform a verification of coffee without making any changes, you can use the `--verify` flag:
 
 ```bash
 coffee nurse --verify
 ```
-_________
+
+---
+
 ### Tipping a plugin in Bitcoin
 
 > ✅ Implemented
@@ -167,7 +194,8 @@ _________
 coffee tip <plugin_name> <millisatoshi>
 ```
 
-------
+---
+
 ## Running coffee as a server
 
 To run Coffee as a server, you can use the `coffee_httpd` binary.
@@ -178,8 +206,8 @@ Please note that the server runs on `localhost` with port `8080` where you can f
 
 To start the Coffee server, run the following command:
 
- ```shell
- coffee_httpd --cln-path <core_lightning_path> --network <network>  
- ```
+```shell
+coffee_httpd --cln-path <core_lightning_path> --network <network>
+```
 
 Make sure the `coffee_httpd` binary is in your system PATH or in the current working directory.


### PR DESCRIPTION
# Description
This PR adds support for `coffee disable` and `coffee enable` commands, allowing users to toggle plugin status without complete uninstallation. 
The implementation ensures backward compatibility by making the new field "enabled" optional in the plugin struct.

Closes #102
# Changes made
- Implemented `disable` and `enable` methods for `CoffeeManager`
- Added CLI commands `coffee enable/disable <plugin_name>`
- Included HTTP endpoints for the new commands
- Updated documentation
# To Do
- Integration testing for both `coffee` and `coffee_httpd`, to be added following #236
- Add `coffee disable --all` to disable all plugins with a single command