### PR TITLE
Add Branch Selection for `coffee_install()`

### DIFF
--- a/coffee_cmd/src/cmd.rs
+++ b/coffee_cmd/src/cmd.rs
@@ -29,6 +29,12 @@ pub enum CoffeeCommand {
         verbose: bool,
         #[arg(short, long, action = clap::ArgAction::SetTrue)]
         dynamic: bool,
+        #[arg(
+            name = "branch",
+            long,
+            help = "The branch to install the plugin from. If not specified, the default branch will be used."
+        )]
+        branch: Option<String>,
     },
     /// upgrade a single repository.
     #[clap(arg_required_else_help = true)]
@@ -98,7 +104,8 @@ impl From<&CoffeeCommand> for coffee_core::CoffeeOperation {
                 plugin,
                 verbose,
                 dynamic,
-            } => Self::Install(plugin.to_owned(), *verbose, *dynamic),
+                branch,
+            } => Self::Install(plugin.to_owned(), *verbose, *dynamic, branch.clone()),
             CoffeeCommand::Upgrade { repo, verbose } => Self::Upgrade(repo.to_owned(), *verbose),
             CoffeeCommand::List {} => Self::List,
             CoffeeCommand::Setup { cln_conf } => Self::Setup(cln_conf.to_owned()),

--- a/coffee_cmd/src/coffee_term/command_show.rs
+++ b/coffee_cmd/src/coffee_term/command_show.rs
@@ -22,6 +22,7 @@ pub fn show_list(coffee_list: Result<CoffeeList, CoffeeError>) -> Result<(), Cof
         term::format::bold(String::from("Language")),
         term::format::bold(String::from("Name")),
         term::format::bold(String::from("Enabled")),
+        term::format::bold(String::from("Git HEAD")),
         term::format::bold(String::from("Exec path")),
     ]);
     table.divider();
@@ -30,6 +31,8 @@ pub fn show_list(coffee_list: Result<CoffeeList, CoffeeError>) -> Result<(), Cof
         // Get whether the plugin is enabled
         // If enabled is None, it means the plugin is enabled by default for backward compatibility.
         let enabled = plugin.enabled.unwrap_or(true);
+        let mut commit = plugin.commit.clone().unwrap_or_default();
+        commit = commit.chars().take(7).collect::<String>();
         table.push([
             term::format::positive("●").into(),
             term::format::highlight(plugin.lang.to_string()),
@@ -39,6 +42,7 @@ pub fn show_list(coffee_list: Result<CoffeeList, CoffeeError>) -> Result<(), Cof
             } else {
                 term::format::negative("no").into()
             },
+            term::format::primary(commit),
             term::format::highlight(plugin.exec_path.to_owned()),
         ])
     }

--- a/coffee_cmd/src/main.rs
+++ b/coffee_cmd/src/main.rs
@@ -20,13 +20,14 @@ async fn run(args: CoffeeArgs, mut coffee: CoffeeManager) -> Result<(), CoffeeEr
             plugin,
             verbose,
             dynamic,
+            branch,
         } => {
             let spinner = if !verbose {
                 Some(term::spinner("Compiling and installing"))
             } else {
                 None
             };
-            let result = coffee.install(&plugin, verbose, dynamic).await;
+            let result = coffee.install(&plugin, verbose, dynamic, branch).await;
             if let Some(spinner) = spinner {
                 if result.is_ok() {
                     spinner.finish();

--- a/coffee_core/src/lib.rs
+++ b/coffee_core/src/lib.rs
@@ -8,7 +8,7 @@ pub use coffee_lib as lib;
 #[derive(Clone, Debug)]
 pub enum CoffeeOperation {
     /// Install(plugin name, verbose run, dynamic installation)
-    Install(String, bool, bool),
+    Install(String, bool, bool, Option<String>),
     /// List
     List,
     // Upgrade(name of the repository, verbose run)

--- a/coffee_github/src/lib.rs
+++ b/coffee_github/src/lib.rs
@@ -3,6 +3,8 @@
 pub mod repository;
 mod utils;
 
+pub use utils::{git_upgrade_with_branch, git_upgrade_with_git_head};
+
 #[cfg(test)]
 mod tests {
     use std::{path::Path, sync::Once};

--- a/coffee_github/src/repository.rs
+++ b/coffee_github/src/repository.rs
@@ -21,7 +21,7 @@ use coffee_storage::model::repository::Kind;
 use coffee_storage::model::repository::Repository as StorageRepository;
 
 use crate::utils::clone_recursive_fix;
-use crate::utils::git_upgrade;
+use crate::utils::git_upgrade_with_branch;
 
 pub struct Github {
     /// the url of the repository to be able
@@ -259,7 +259,7 @@ impl Repository for Github {
             }
         }
         // pull the changes from the repository
-        let status = git_upgrade(&self.url.path_string, &self.branch, verbose).await?;
+        let status = git_upgrade_with_branch(&self.url.path_string, &self.branch, verbose).await?;
         self.git_head = Some(status.commit_id());
         self.last_activity = Some(status.date());
         Ok(CoffeeUpgrade {
@@ -334,6 +334,11 @@ impl Repository for Github {
             }
         }
         None
+    }
+
+    /// return the git head of the repository.
+    fn git_head(&self) -> Option<String> {
+        self.git_head.clone()
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/coffee_httpd/src/httpd/server.rs
+++ b/coffee_httpd/src/httpd/server.rs
@@ -93,7 +93,7 @@ async fn coffee_install(
     let try_dynamic = body.try_dynamic;
 
     let mut coffee = data.coffee.lock().await;
-    let result = coffee.install(plugin, false, try_dynamic).await;
+    let result = coffee.install(plugin, false, try_dynamic, None).await;
 
     handle_httpd_response!(result, "Plugin '{plugin}' installed successfully")
 }

--- a/coffee_lib/src/plugin_manager.rs
+++ b/coffee_lib/src/plugin_manager.rs
@@ -16,6 +16,7 @@ pub trait PluginManager {
         plugins: &str,
         verbose: bool,
         try_dynamic: bool,
+        branch: Option<String>,
     ) -> Result<(), CoffeeError>;
 
     // remove a plugin by name, return an error if some error happens.

--- a/coffee_lib/src/repository.rs
+++ b/coffee_lib/src/repository.rs
@@ -40,5 +40,8 @@ pub trait Repository: Any {
     /// return the url of the repository.
     fn url(&self) -> URL;
 
+    /// return the git head of the repository.
+    fn git_head(&self) -> Option<String>;
+
     fn as_any(&self) -> &dyn Any;
 }

--- a/coffee_plugin/src/plugin/plugin_mod.rs
+++ b/coffee_plugin/src/plugin/plugin_mod.rs
@@ -91,7 +91,7 @@ fn coffee_install(plugin: &mut Plugin<State>, request: Value) -> Result<Value, P
     let rt = Runtime::new().unwrap();
 
     let request: InstallReq = serde_json::from_value(request)?;
-    rt.block_on(coffee.install(&request.name, false, true))
+    rt.block_on(coffee.install(&request.name, false, true, None))
         .map_err(from)?;
     Ok(json!({}))
 }

--- a/docs/docs-book/src/using-coffee.md
+++ b/docs/docs-book/src/using-coffee.md
@@ -104,6 +104,14 @@ To install a plugin statically, you simply need to run.
 coffee install <plugin_name>
 ```
 
+#### Specifying a branch for installation
+
+To install a plugin from a specific branch, you simply need to run.
+
+```bash
+coffee install <plugin_name> --branch <branch_name>
+```
+
 ### Removing a Plugin
 
 > ✅ Implemented

--- a/tests/src/coffee_integration_tests.rs
+++ b/tests/src/coffee_integration_tests.rs
@@ -112,7 +112,7 @@ pub async fn init_coffee_test_add_remote() {
         .unwrap();
     manager
         .coffee()
-        .install("summary", true, true)
+        .install("summary", true, true, None)
         .await
         .unwrap();
 
@@ -167,13 +167,13 @@ pub async fn test_add_remove_plugins() {
     );
 
     // Install summary plugin
-    let result = manager.coffee().install("summary", true, false).await;
+    let result = manager.coffee().install("summary", true, false, None).await;
     assert!(result.is_ok(), "{:?}", result);
 
     // Install helpme plugin
     manager
         .coffee()
-        .install("helpme", true, false)
+        .install("helpme", true, false, None)
         .await
         .unwrap();
 
@@ -276,7 +276,7 @@ pub async fn test_errors_and_show() {
     );
 
     // Install summary plugin
-    let result = manager.coffee().install("summary", true, false).await;
+    let result = manager.coffee().install("summary", true, false, None).await;
     assert!(result.is_ok(), "{:?}", result);
 
     // Get the README file for a plugin that is not installed
@@ -285,7 +285,7 @@ pub async fn test_errors_and_show() {
     assert!(val.starts_with("# Helpme plugin"));
 
     // Install a plugin that is not in the repository
-    let result = manager.coffee().install("x", true, false).await;
+    let result = manager.coffee().install("x", true, false, None).await;
     assert!(result.is_err(), "{:?}", result);
 
     // Remove helpme plugin
@@ -353,7 +353,7 @@ pub async fn install_plugin_in_two_networks() -> anyhow::Result<()> {
     // This should install summary plugin for regtest network
     manager
         .coffee()
-        .install("summary", true, true)
+        .install("summary", true, true, None)
         .await
         .unwrap();
     // Ensure that summary is installed for regtest network
@@ -393,7 +393,7 @@ pub async fn install_plugin_in_two_networks() -> anyhow::Result<()> {
     // This should install summary plugin for testnet network
     manager
         .coffee()
-        .install("summary", true, true)
+        .install("summary", true, true, None)
         .await
         .unwrap();
     // Ensure that summary is installed for testnet network
@@ -428,13 +428,13 @@ pub async fn test_double_slash() {
         .unwrap();
 
     // Install summary plugin
-    let result = manager.coffee().install("summary", true, false).await;
+    let result = manager.coffee().install("summary", true, false, None).await;
     assert!(result.is_ok(), "{:?}", result);
 
     // Install helpme plugin
     manager
         .coffee()
-        .install("helpme", true, false)
+        .install("helpme", true, false, None)
         .await
         .unwrap();
 
@@ -493,7 +493,7 @@ pub async fn test_plugin_installation_path() {
     // Install summary plugin for regtest network
     manager
         .coffee()
-        .install("summary", true, false)
+        .install("summary", true, false, None)
         .await
         .unwrap();
 


### PR DESCRIPTION
## Description

Add branch selection for `coffee_install` and display plugin git HEAD in `coffee list`.
Fixes #205

## Changes
- Added `Repository::git_head()` to retrieve the repository's git HEAD.
- Added an optional `branch` parameter to `coffee_install()` for branch selection during installation.
- Implemented `git_upgrade_with_git_head()` for checkout using a specific git HEAD.
- Updated `cmd`, `coffee_plugin`, and `coffee httpd` to pass the branch value.
- Modified `coffee list` output to display the git HEAD of plugins.

## Testing
```bash
coffee install <plugin_name> --branch <branch_name>
```