### PR TITLE
install command: add -T option to cp to not create nested folders on duplicate calls

### DIFF
--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -270,7 +270,7 @@ impl PluginManager for CoffeeManager {
                     old_root_path,
                     new_root_path
                 );
-                let script = format!("cp -r {old_root_path} {new_root_path}");
+                let script = format!("cp -r -T {old_root_path} {new_root_path}");
                 sh!(self.config.root_path.clone(), script, verbose);
                 log::debug!(
                     "Done! copying directory from {} inside the new one {}",


### PR DESCRIPTION
If you call coffee install more than once it will create folders like this:

1. ~/.coffee/<network>/plugins/<plugin_name>
2. ~/.coffee/<network>/plugins/<plugin_name>/<plugin_name>

the -T option for cp should fix this.