### PR TITLE
Always print install errors

### DIFF
--- a/coffee_cmd/src/main.rs
+++ b/coffee_cmd/src/main.rs
@@ -26,15 +26,15 @@ async fn run(args: CoffeeArgs, mut coffee: CoffeeManager) -> Result<(), CoffeeEr
             } else {
                 None
             };
-            let result = coffee.install(&plugin, verbose, dynamic).await;
-            if let Some(spinner) = spinner {
-                if result.is_ok() {
-                    spinner.finish();
-                } else {
-                    spinner.failed();
+            match coffee.install(&plugin, verbose, dynamic).await {
+                Ok(_) => {
+                    spinner.and_then(|spinner| Some(spinner.finish()));
+                    term::success!("Plugin {plugin} Compiled and Installed")
                 }
-            } else if result.is_ok() {
-                term::success!("Plugin {plugin} Compiled and Installed")
+                Err(err) => {
+                    spinner.and_then(|spinner| Some(spinner.failed()));
+                    term::error(format!("{err}"))
+                }
             }
         }
         CoffeeCommand::Remove { plugin } => {


### PR DESCRIPTION
When running `coffee install` and there is an error e.g. the plugin could not be started by cln, coffee does not print an error. Not even in `verbose` mode. Only with the `RUST_LOG` env you can eventually see what happens. I propose to always show an install error to the user who just follows the documentation.