### PR TITLE
fix: do not allow install duplicated plugin

### DIFF
--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -277,7 +277,7 @@ impl PluginManager for CoffeeManager {
                     old_root_path,
                     new_root_path
                 );
-                let script = format!("cp -r -T {old_root_path} {new_root_path}");
+                let script = format!("cp -r {old_root_path} {new_root_path}");
                 sh!(self.config.root_path.clone(), script, verbose);
                 log::debug!(
                     "Done! copying directory from {} inside the new one {}",

--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -247,6 +247,13 @@ impl PluginManager for CoffeeManager {
         verbose: bool,
         try_dynamic: bool,
     ) -> Result<(), CoffeeError> {
+        let mut plugins = self.config.plugins.clone();
+        plugins.retain(|p| p.name().eq(plugin));
+
+        if !plugins.is_empty() {
+            return Err(error!("Plugin with name `{plugin}` already installed"));
+        }
+
         log::debug!("installing plugin: {plugin}");
         // keep track if the plugin is successfully installed
         for repo in self.repos.values() {


### PR DESCRIPTION
Potential fixes https://github.com/coffee-tools/coffee/issues/246

also @tareknaser noted that the commit https://github.com/coffee-tools/coffee/commit/eb4f6d29efcb7e715e8339b706e7219fec54cfa2 does not make sense because we will never duplicate directory

This was caused by the plugin duplication bug