### PR TITLE
fix: tip function sent unwanted amount and expected wrong response

### DIFF
--- a/coffee_core/src/coffee.rs
+++ b/coffee_core/src/coffee.rs
@@ -586,15 +586,23 @@ impl PluginManager for CoffeeManager {
                 }),
             )
             .await?;
-        let tip: CoffeeTip = self
+        let pay: PayResponse = self
             .cln(
                 "pay",
                 json!({
                     "bolt11": invoice.invoice,
-                    "amount_msat": amount_msat,
                 }),
             )
             .await?;
+        let tip = CoffeeTip {
+            for_plugin: plugin.name(),
+            invoice: invoice.invoice,
+            status: pay.status,
+            destination: pay.destination,
+            amount_msat: pay.amount_msat,
+            amount_sent_msat: pay.amount_sent_msat,
+            warning_partial_completion: pay.warning_partial_completion,
+        };
         Ok(tip)
     }
 

--- a/coffee_lib/src/types/mod.rs
+++ b/coffee_lib/src/types/mod.rs
@@ -258,4 +258,17 @@ pub mod response {
         pub amount_sent_msat: u64,
         pub warning_partial_completion: Option<String>,
     }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct PayResponse {
+        pub payment_preimage: String,
+        pub destination: Option<String>,
+        pub payment_hash: String,
+        pub created_at: f64,
+        pub parts: u32,
+        pub amount_msat: u64,
+        pub amount_sent_msat: u64,
+        pub warning_partial_completion: Option<String>,
+        pub status: String,
+    }
 }


### PR DESCRIPTION
When fetching an invoice with an amount and then paying that invoice cln will error if you've sent an amount on the pay command aswell.

Tip also expected an incompatible `CoffeeTip` response from `pay`. `pay` responses don't have a field `for_plugin` or `invoice`

tested with cln 24.02rc2