### PR TITLE
core: remove repo path from url

### DIFF
--- a/coffee_core/src/nurse/strategy.rs
+++ b/coffee_core/src/nurse/strategy.rs
@@ -56,9 +56,9 @@ impl Handler for GitRepositoryLocallyAbsentStrategy {
         let mut repos: Vec<String> = Vec::new();
         let coffee_repos = &coffee.repos;
         for repo in coffee_repos.values() {
+            let repo_home = repo.home();
             log::debug!("Checking if repository {} exists locally", repo.name());
-            let repo_path = repo.url().path_string;
-            let repo_path = Path::new(&repo_path);
+            let repo_path = Path::new(&repo_home);
             if !repo_path.exists() {
                 log::debug!("Repository {} is missing locally", repo.name());
                 repos.push(repo.name().to_string());

--- a/coffee_github/src/utils.rs
+++ b/coffee_github/src/utils.rs
@@ -1,17 +1,19 @@
 use coffee_lib::errors::CoffeeError;
 use coffee_lib::macros::error;
-use coffee_lib::url::URL;
 use coffee_lib::{commit_id, get_repo_info, sh};
 use log::debug;
 
 use coffee_lib::types::response::UpgradeStatus;
 
-pub async fn clone_recursive_fix(repo: git2::Repository, url: &URL) -> Result<(), CoffeeError> {
+pub async fn clone_recursive_fix(
+    repo: git2::Repository,
+    root_path: &str,
+) -> Result<(), CoffeeError> {
     let repository = repo.submodules().unwrap_or_default();
     debug!("submodule count: {}", repository.len());
     for (index, sub) in repository.iter().enumerate() {
         debug!("url {}: {}", index + 1, sub.url().unwrap());
-        let path = format!("{}/{}", &url.path_string, sub.path().to_str().unwrap());
+        let path = format!("{}/{}", root_path, sub.path().to_str().unwrap());
         match git2::Repository::clone(sub.url().unwrap(), &path) {
             // Fix error handling
             Ok(_) => {

--- a/coffee_lib/src/plugin_manager.rs
+++ b/coffee_lib/src/plugin_manager.rs
@@ -75,4 +75,15 @@ pub trait PluginManager {
 
     /// enable a plugin by name
     async fn enable(&mut self, plugin: &str) -> Result<(), CoffeeError>;
+
+    /// The repositories home directory, where all the dirs
+    /// will be copied and cloned
+    fn repositories_home(&self) -> String;
+
+    /// The plugins home directory
+    ///
+    /// When we install a plugin we will have to copy it in
+    /// another plugin directory and this is the home
+    /// (aka root path for it).
+    fn plugins_home(&self) -> String;
 }

--- a/coffee_lib/src/repository.rs
+++ b/coffee_lib/src/repository.rs
@@ -41,4 +41,6 @@ pub trait Repository: Any {
     fn url(&self) -> URL;
 
     fn as_any(&self) -> &dyn Any;
+
+    fn home(&self) -> String;
 }

--- a/coffee_lib/src/url.rs
+++ b/coffee_lib/src/url.rs
@@ -11,10 +11,12 @@ pub struct URL {
     pub name: String,
     /// the url string
     pub url_string: String,
-    /// the coffee path associated with the url
-    pub path_string: String,
     /// the repo name associated with the url
     pub repo_name: String,
+    #[deprecated(
+        note = "this value is used only for migration from db, a caller you never use this value"
+    )]
+    pub path_string: Option<String>,
 }
 
 /// Handle GitHub HTTP links
@@ -48,23 +50,19 @@ fn get_repo_name_from_url(url: &str) -> String {
 
 impl URL {
     /// Build a new URL and initialize its fields
-    pub fn new(local_path: &str, url: &str, remote_name: &str) -> Self {
+    pub fn new(url: &str, remote_name: &str) -> Self {
         URL {
             name: remote_name.to_owned(),
             url_string: handle_incorrect_url(url),
-            path_string: format!("{local_path}/repositories/{remote_name}"),
             repo_name: get_repo_name_from_url(url),
+            path_string: None,
         }
     }
 }
 
 impl fmt::Display for URL {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "repo_name: {}, url: {}, path: {}",
-            self.repo_name, self.url_string, self.path_string
-        )
+        write!(f, "repo_name: {}, url: {}", self.repo_name, self.url_string)
     }
 }
 
@@ -75,9 +73,8 @@ mod tests {
     #[test]
     fn test_remote() {
         let u = "https://github.com/lightningd/plugins";
-        let url = URL::new("/tmp/", u, "lightningd_plugins");
+        let url = URL::new(u, "lightningd_plugins");
         assert_eq!(url.repo_name, "plugins");
         assert_eq!(url.url_string, u);
-        println!("{}", &url);
     }
 }

--- a/coffee_storage/src/model/repository.rs
+++ b/coffee_storage/src/model/repository.rs
@@ -12,6 +12,10 @@ pub enum Kind {
 pub struct Repository {
     pub kind: Kind,
     pub name: String,
+    #[deprecated(
+        note = "make this not optional, the optional value is good just for db migration"
+    )]
+    pub root_path: Option<String>,
     pub url: URL,
     pub plugins: Vec<Plugin>,
     pub branch: String,


### PR DESCRIPTION
This is a preparation work to simplify the PR https://github.com/coffee-tools/coffee/pull/239

looking right now if it is possible to remove the plugin path from the struct, but looks like a little bit tricky? maybe no