### PR TITLE
chore(cmd): organize imports properly

### DIFF
--- a/coffee_cmd/src/cmd.rs
+++ b/coffee_cmd/src/cmd.rs
@@ -1,8 +1,10 @@
 //! Coffee command line arguments definition.
+use std::fmt::Display;
+
 use clap::{Parser, Subcommand};
+
 use coffee_lib::error;
 use coffee_lib::errors::CoffeeError;
-use std::fmt::Display;
 
 /// Coffee main command line definition for the command line tools.
 #[derive(Debug, Parser)]


### PR DESCRIPTION
This PR addresses @vincenzopalazzo comment [here](https://github.com/coffee-tools/coffee/pull/274#discussion_r1596915003) to follow the import rule on the codebase.